### PR TITLE
Feature/makefile2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 glide.lock
+.go.get
 swagger
 vendor/
 client/

--- a/glide-swagger.yaml
+++ b/glide-swagger.yaml
@@ -1,4 +1,7 @@
 package: github.com/emccode/gorackhd
+ignore:
+- client
+- models
 import:
   - package: github.com/go-swagger/go-swagger
     ref:     bb86d63b17832bd6d930101040119a803c456f70

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,6 @@
+package: github.com/emccode/gorackhd
+import:
+  - package: github.com/go-swagger/go-swagger
+    repo:    https://github.com/akutz/go-swagger
+    ref:     036d71a8fdc008cef34e4a6cd62cb4ed8333b594
+    vcs:     git

--- a/gorackhd.go
+++ b/gorackhd.go
@@ -1,7 +1,10 @@
 package gorackhd
 
 import (
-	// import for build
+	// import go-swagger so it can generate the bindings
+	_ "github.com/go-swagger/go-swagger"
+
+	// import the generated go-swagger bindings
 	_ "github.com/emccode/gorackhd/client"
 	_ "github.com/emccode/gorackhd/models"
 )


### PR DESCRIPTION
This patch improves the Makefile so that a two-phase approach is used for downloading project dependencies. The first phase uses the file `glide-swagger.yaml` to download _only_ the requested version of go-swagger that is necessary to generate the client bindings. Once the bindings are generated the second phase uses the standard `glide.yaml` to scan the entire project to fetch the remaining dependencies, this time including the `client` and `models` packages.

The following example shows what executing `make` _would_ do by using the `-n` flag with it:

``` shell
[0]akutz@pax:gorackhd$ make -n
/Users/akutz/Projects/go/bin/glide --home /Users/akutz up --quick --use-gopath --file glide-swagger.yaml
cd vendor/github.com/go-swagger/go-swagger/cmd/ && go build -o /Users/akutz/Projects/go/src/github.com/emccode/gorackhd/swagger ./swagger && cd /Users/akutz/Projects/go/src/github.com/emccode/gorackhd
/Users/akutz/Projects/go/src/github.com/emccode/gorackhd/swagger generate client -f swagger-spec/monorail.yml
/Users/akutz/Projects/go/bin/glide --home /Users/akutz up
go get -d $(/Users/akutz/Projects/go/bin/glide nv) && touch .go.get
go install -v $(/Users/akutz/Projects/go/bin/glide nv)
[0]akutz@pax:gorackhd$ 
```
