### PR TITLE
Add top-level client constructor

### DIFF
--- a/gorackhd.go
+++ b/gorackhd.go
@@ -5,6 +5,13 @@ import (
 	_ "github.com/go-swagger/go-swagger"
 
 	// import the generated go-swagger bindings
-	_ "github.com/emccode/gorackhd/client"
+	"github.com/emccode/gorackhd/client"
 	_ "github.com/emccode/gorackhd/models"
+
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
 )
+
+func GetClient(host, basePath string, schemes []string) *client.Monorail {
+	return client.New(httptransport.New(host, basePath, schemes), strfmt.Default)
+}


### PR DESCRIPTION
Since gorackhd is vendoring go-swagger (which pulls in go-openapi),
conflicts arise if gorackhd clients are forced to import go-openapi as
well. Fix that by creating a top-level constructure, which will
automatically use the vendored versions of the go-openapi library.
