### PR TITLE
Return arrays instead of objects for many GETs

### DIFF
--- a/client/catalog/get_catalogs_identifier_responses.go
+++ b/client/catalog/get_catalogs_identifier_responses.go
@@ -49,7 +49,7 @@ func NewGetCatalogsIdentifierOK() *GetCatalogsIdentifierOK {
 A single catalog
 */
 type GetCatalogsIdentifierOK struct {
-	Payload []*models.Catalog
+	Payload *models.Catalog
 }
 
 func (o *GetCatalogsIdentifierOK) Error() string {
@@ -58,8 +58,10 @@ func (o *GetCatalogsIdentifierOK) Error() string {
 
 func (o *GetCatalogsIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Catalog)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/client/catalogs/get_nodes_identifier_catalogs_responses.go
+++ b/client/catalogs/get_nodes_identifier_catalogs_responses.go
@@ -57,7 +57,7 @@ all catalogs of specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierCatalogsOK struct {
-	Payload GetNodesIdentifierCatalogsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierCatalogsOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierCatalogsDefault) readResponse(response runtime.Client
 
 	return nil
 }
-
-/*GetNodesIdentifierCatalogsOKBodyBody get nodes identifier catalogs o k body body
-
-swagger:model GetNodesIdentifierCatalogsOKBodyBody
-*/
-type GetNodesIdentifierCatalogsOKBodyBody interface{}

--- a/client/config/get_config_responses.go
+++ b/client/config/get_config_responses.go
@@ -46,7 +46,7 @@ func NewGetConfigOK() *GetConfigOK {
 
 /*GetConfigOK handles this case with default header values.
 
-An array of configuration objects
+Configuration object
 */
 type GetConfigOK struct {
 	Payload GetConfigOKBodyBody

--- a/client/dhcp/get_dhcp_lease_mac_responses.go
+++ b/client/dhcp/get_dhcp_lease_mac_responses.go
@@ -49,7 +49,7 @@ func NewGetDhcpLeaseMacOK() *GetDhcpLeaseMacOK {
 A single lease
 */
 type GetDhcpLeaseMacOK struct {
-	Payload []*models.Lease
+	Payload *models.Lease
 }
 
 func (o *GetDhcpLeaseMacOK) Error() string {
@@ -58,8 +58,10 @@ func (o *GetDhcpLeaseMacOK) Error() string {
 
 func (o *GetDhcpLeaseMacOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Lease)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/client/files/files_client.go
+++ b/client/files/files_client.go
@@ -86,7 +86,7 @@ PutFilesFileidentifier puts file based on filename
 Put file based on filename, returns the uuid of the stored file.
 
 */
-func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierOK, error) {
+func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutFilesFileidentifierParams()
@@ -106,7 +106,7 @@ func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, au
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PutFilesFileidentifierOK), nil
+	return result.(*PutFilesFileidentifierCreated), nil
 }
 
 // SetTransport changes the transport on the client

--- a/client/get/get_catalogs_identifier_responses.go
+++ b/client/get/get_catalogs_identifier_responses.go
@@ -49,7 +49,7 @@ func NewGetCatalogsIdentifierOK() *GetCatalogsIdentifierOK {
 A single catalog
 */
 type GetCatalogsIdentifierOK struct {
-	Payload []*models.Catalog
+	Payload *models.Catalog
 }
 
 func (o *GetCatalogsIdentifierOK) Error() string {
@@ -58,8 +58,10 @@ func (o *GetCatalogsIdentifierOK) Error() string {
 
 func (o *GetCatalogsIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Catalog)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/client/get/get_config_responses.go
+++ b/client/get/get_config_responses.go
@@ -46,7 +46,7 @@ func NewGetConfigOK() *GetConfigOK {
 
 /*GetConfigOK handles this case with default header values.
 
-An array of configuration objects
+Configuration object
 */
 type GetConfigOK struct {
 	Payload GetConfigOKBodyBody

--- a/client/get/get_dhcp_lease_mac_responses.go
+++ b/client/get/get_dhcp_lease_mac_responses.go
@@ -49,7 +49,7 @@ func NewGetDhcpLeaseMacOK() *GetDhcpLeaseMacOK {
 A single lease
 */
 type GetDhcpLeaseMacOK struct {
-	Payload []*models.Lease
+	Payload *models.Lease
 }
 
 func (o *GetDhcpLeaseMacOK) Error() string {
@@ -58,8 +58,10 @@ func (o *GetDhcpLeaseMacOK) Error() string {
 
 func (o *GetDhcpLeaseMacOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Lease)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/client/get/get_nodes_identifier_catalogs_responses.go
+++ b/client/get/get_nodes_identifier_catalogs_responses.go
@@ -57,7 +57,7 @@ all catalogs of specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierCatalogsOK struct {
-	Payload GetNodesIdentifierCatalogsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierCatalogsOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierCatalogsDefault) readResponse(response runtime.Client
 
 	return nil
 }
-
-/*GetNodesIdentifierCatalogsOKBodyBody get nodes identifier catalogs o k body body
-
-swagger:model GetNodesIdentifierCatalogsOKBodyBody
-*/
-type GetNodesIdentifierCatalogsOKBodyBody interface{}

--- a/client/get/get_nodes_identifier_obm_responses.go
+++ b/client/get/get_nodes_identifier_obm_responses.go
@@ -56,7 +56,7 @@ func NewGetNodesIdentifierObmOK() *GetNodesIdentifierObmOK {
 obm settings
 */
 type GetNodesIdentifierObmOK struct {
-	Payload GetNodesIdentifierObmOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierObmOK) Error() string {
@@ -140,9 +140,3 @@ func (o *GetNodesIdentifierObmDefault) readResponse(response runtime.ClientRespo
 
 	return nil
 }
-
-/*GetNodesIdentifierObmOKBodyBody get nodes identifier obm o k body body
-
-swagger:model GetNodesIdentifierObmOKBodyBody
-*/
-type GetNodesIdentifierObmOKBodyBody interface{}

--- a/client/get/get_nodes_identifier_pollers_responses.go
+++ b/client/get/get_nodes_identifier_pollers_responses.go
@@ -57,7 +57,7 @@ all pollers of specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierPollersOK struct {
-	Payload GetNodesIdentifierPollersOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierPollersOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierPollersDefault) readResponse(response runtime.ClientR
 
 	return nil
 }
-
-/*GetNodesIdentifierPollersOKBodyBody get nodes identifier pollers o k body body
-
-swagger:model GetNodesIdentifierPollersOKBodyBody
-*/
-type GetNodesIdentifierPollersOKBodyBody interface{}

--- a/client/get/get_nodes_identifier_workflows_responses.go
+++ b/client/get/get_nodes_identifier_workflows_responses.go
@@ -57,7 +57,7 @@ all workflows for specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierWorkflowsOK struct {
-	Payload GetNodesIdentifierWorkflowsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierWorkflowsOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierWorkflowsDefault) readResponse(response runtime.Clien
 
 	return nil
 }
-
-/*GetNodesIdentifierWorkflowsOKBodyBody get nodes identifier workflows o k body body
-
-swagger:model GetNodesIdentifierWorkflowsOKBodyBody
-*/
-type GetNodesIdentifierWorkflowsOKBodyBody interface{}

--- a/client/get/get_obms_library_responses.go
+++ b/client/get/get_obms_library_responses.go
@@ -50,7 +50,7 @@ get list of possible OBM services
 
 */
 type GetObmsLibraryOK struct {
-	Payload GetObmsLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetObmsLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetObmsLibraryDefault) readResponse(response runtime.ClientResponse, co
 
 	return nil
 }
-
-/*GetObmsLibraryOKBodyBody get obms library o k body body
-
-swagger:model GetObmsLibraryOKBodyBody
-*/
-type GetObmsLibraryOKBodyBody interface{}

--- a/client/get/get_pollers_library_responses.go
+++ b/client/get/get_pollers_library_responses.go
@@ -50,7 +50,7 @@ list of all pollers
 
 */
 type GetPollersLibraryOK struct {
-	Payload GetPollersLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetPollersLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetPollersLibraryDefault) readResponse(response runtime.ClientResponse,
 
 	return nil
 }
-
-/*GetPollersLibraryOKBodyBody get pollers library o k body body
-
-swagger:model GetPollersLibraryOKBodyBody
-*/
-type GetPollersLibraryOKBodyBody interface{}

--- a/client/get/get_pollers_responses.go
+++ b/client/get/get_pollers_responses.go
@@ -50,7 +50,7 @@ list of all pollers
 
 */
 type GetPollersOK struct {
-	Payload GetPollersOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetPollersOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetPollersDefault) readResponse(response runtime.ClientResponse, consum
 
 	return nil
 }
-
-/*GetPollersOKBodyBody get pollers o k body body
-
-swagger:model GetPollersOKBodyBody
-*/
-type GetPollersOKBodyBody interface{}

--- a/client/get/get_profiles_library_responses.go
+++ b/client/get/get_profiles_library_responses.go
@@ -50,7 +50,7 @@ list of possible profiles
 
 */
 type GetProfilesLibraryOK struct {
-	Payload GetProfilesLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetProfilesLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetProfilesLibraryDefault) readResponse(response runtime.ClientResponse
 
 	return nil
 }
-
-/*GetProfilesLibraryOKBodyBody get profiles library o k body body
-
-swagger:model GetProfilesLibraryOKBodyBody
-*/
-type GetProfilesLibraryOKBodyBody interface{}

--- a/client/get/get_skus_identifier_nodes_responses.go
+++ b/client/get/get_skus_identifier_nodes_responses.go
@@ -57,7 +57,7 @@ return nodes associated with that sku
 
 */
 type GetSkusIdentifierNodesOK struct {
-	Payload GetSkusIdentifierNodesOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetSkusIdentifierNodesOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetSkusIdentifierNodesDefault) readResponse(response runtime.ClientResp
 
 	return nil
 }
-
-/*GetSkusIdentifierNodesOKBodyBody get skus identifier nodes o k body body
-
-swagger:model GetSkusIdentifierNodesOKBodyBody
-*/
-type GetSkusIdentifierNodesOKBodyBody interface{}

--- a/client/get/get_skus_responses.go
+++ b/client/get/get_skus_responses.go
@@ -50,7 +50,7 @@ list of skus
 
 */
 type GetSkusOK struct {
-	Payload GetSkusOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetSkusOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetSkusDefault) readResponse(response runtime.ClientResponse, consumer 
 
 	return nil
 }
-
-/*GetSkusOKBodyBody get skus o k body body
-
-swagger:model GetSkusOKBodyBody
-*/
-type GetSkusOKBodyBody interface{}

--- a/client/get/get_templates_library_responses.go
+++ b/client/get/get_templates_library_responses.go
@@ -50,7 +50,7 @@ list of possible templates
 
 */
 type GetTemplatesLibraryOK struct {
-	Payload GetTemplatesLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetTemplatesLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetTemplatesLibraryDefault) readResponse(response runtime.ClientRespons
 
 	return nil
 }
-
-/*GetTemplatesLibraryOKBodyBody get templates library o k body body
-
-swagger:model GetTemplatesLibraryOKBodyBody
-*/
-type GetTemplatesLibraryOKBodyBody interface{}

--- a/client/get/get_workflows_library_injectable_name_responses.go
+++ b/client/get/get_workflows_library_injectable_name_responses.go
@@ -48,7 +48,7 @@ List all workflows available to run
 
 */
 type GetWorkflowsLibraryInjectableNameOK struct {
-	Payload GetWorkflowsLibraryInjectableNameOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsLibraryInjectableNameOK) Error() string {
@@ -106,9 +106,3 @@ func (o *GetWorkflowsLibraryInjectableNameDefault) readResponse(response runtime
 swagger:model GetWorkflowsLibraryInjectableNameDefaultBodyBody
 */
 type GetWorkflowsLibraryInjectableNameDefaultBodyBody interface{}
-
-/*GetWorkflowsLibraryInjectableNameOKBodyBody get workflows library injectable name o k body body
-
-swagger:model GetWorkflowsLibraryInjectableNameOKBodyBody
-*/
-type GetWorkflowsLibraryInjectableNameOKBodyBody interface{}

--- a/client/get/get_workflows_library_responses.go
+++ b/client/get/get_workflows_library_responses.go
@@ -50,7 +50,7 @@ List all workflows available to run
 
 */
 type GetWorkflowsLibraryOK struct {
-	Payload GetWorkflowsLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsLibraryDefault) readResponse(response runtime.ClientRespons
 
 	return nil
 }
-
-/*GetWorkflowsLibraryOKBodyBody get workflows library o k body body
-
-swagger:model GetWorkflowsLibraryOKBodyBody
-*/
-type GetWorkflowsLibraryOKBodyBody interface{}

--- a/client/get/get_workflows_responses.go
+++ b/client/get/get_workflows_responses.go
@@ -50,7 +50,7 @@ Fetch workflows
 
 */
 type GetWorkflowsOK struct {
-	Payload GetWorkflowsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsDefault) readResponse(response runtime.ClientResponse, cons
 
 	return nil
 }
-
-/*GetWorkflowsOKBodyBody get workflows o k body body
-
-swagger:model GetWorkflowsOKBodyBody
-*/
-type GetWorkflowsOKBodyBody interface{}

--- a/client/get/get_workflows_tasks_library_responses.go
+++ b/client/get/get_workflows_tasks_library_responses.go
@@ -50,7 +50,7 @@ List workflow tasks library
 
 */
 type GetWorkflowsTasksLibraryOK struct {
-	Payload GetWorkflowsTasksLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsTasksLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsTasksLibraryDefault) readResponse(response runtime.ClientRe
 
 	return nil
 }
-
-/*GetWorkflowsTasksLibraryOKBodyBody get workflows tasks library o k body body
-
-swagger:model GetWorkflowsTasksLibraryOKBodyBody
-*/
-type GetWorkflowsTasksLibraryOKBodyBody interface{}

--- a/client/get/get_workflows_tasks_responses.go
+++ b/client/get/get_workflows_tasks_responses.go
@@ -50,7 +50,7 @@ Fetch tasks from task library
 
 */
 type GetWorkflowsTasksOK struct {
-	Payload GetWorkflowsTasksOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsTasksOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsTasksDefault) readResponse(response runtime.ClientResponse,
 
 	return nil
 }
-
-/*GetWorkflowsTasksOKBodyBody get workflows tasks o k body body
-
-swagger:model GetWorkflowsTasksOKBodyBody
-*/
-type GetWorkflowsTasksOKBodyBody interface{}

--- a/client/nodes/get_nodes_identifier_catalogs_responses.go
+++ b/client/nodes/get_nodes_identifier_catalogs_responses.go
@@ -57,7 +57,7 @@ all catalogs of specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierCatalogsOK struct {
-	Payload GetNodesIdentifierCatalogsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierCatalogsOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierCatalogsDefault) readResponse(response runtime.Client
 
 	return nil
 }
-
-/*GetNodesIdentifierCatalogsOKBodyBody get nodes identifier catalogs o k body body
-
-swagger:model GetNodesIdentifierCatalogsOKBodyBody
-*/
-type GetNodesIdentifierCatalogsOKBodyBody interface{}

--- a/client/nodes/get_nodes_identifier_obm_responses.go
+++ b/client/nodes/get_nodes_identifier_obm_responses.go
@@ -56,7 +56,7 @@ func NewGetNodesIdentifierObmOK() *GetNodesIdentifierObmOK {
 obm settings
 */
 type GetNodesIdentifierObmOK struct {
-	Payload GetNodesIdentifierObmOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierObmOK) Error() string {
@@ -140,9 +140,3 @@ func (o *GetNodesIdentifierObmDefault) readResponse(response runtime.ClientRespo
 
 	return nil
 }
-
-/*GetNodesIdentifierObmOKBodyBody get nodes identifier obm o k body body
-
-swagger:model GetNodesIdentifierObmOKBodyBody
-*/
-type GetNodesIdentifierObmOKBodyBody interface{}

--- a/client/nodes/get_nodes_identifier_pollers_responses.go
+++ b/client/nodes/get_nodes_identifier_pollers_responses.go
@@ -57,7 +57,7 @@ all pollers of specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierPollersOK struct {
-	Payload GetNodesIdentifierPollersOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierPollersOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierPollersDefault) readResponse(response runtime.ClientR
 
 	return nil
 }
-
-/*GetNodesIdentifierPollersOKBodyBody get nodes identifier pollers o k body body
-
-swagger:model GetNodesIdentifierPollersOKBodyBody
-*/
-type GetNodesIdentifierPollersOKBodyBody interface{}

--- a/client/nodes/get_nodes_identifier_workflows_responses.go
+++ b/client/nodes/get_nodes_identifier_workflows_responses.go
@@ -57,7 +57,7 @@ all workflows for specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierWorkflowsOK struct {
-	Payload GetNodesIdentifierWorkflowsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierWorkflowsOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierWorkflowsDefault) readResponse(response runtime.Clien
 
 	return nil
 }
-
-/*GetNodesIdentifierWorkflowsOKBodyBody get nodes identifier workflows o k body body
-
-swagger:model GetNodesIdentifierWorkflowsOKBodyBody
-*/
-type GetNodesIdentifierWorkflowsOKBodyBody interface{}

--- a/client/nodes/get_skus_identifier_nodes_responses.go
+++ b/client/nodes/get_skus_identifier_nodes_responses.go
@@ -57,7 +57,7 @@ return nodes associated with that sku
 
 */
 type GetSkusIdentifierNodesOK struct {
-	Payload GetSkusIdentifierNodesOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetSkusIdentifierNodesOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetSkusIdentifierNodesDefault) readResponse(response runtime.ClientResp
 
 	return nil
 }
-
-/*GetSkusIdentifierNodesOKBodyBody get skus identifier nodes o k body body
-
-swagger:model GetSkusIdentifierNodesOKBodyBody
-*/
-type GetSkusIdentifierNodesOKBodyBody interface{}

--- a/client/obm/get_nodes_identifier_obm_responses.go
+++ b/client/obm/get_nodes_identifier_obm_responses.go
@@ -56,7 +56,7 @@ func NewGetNodesIdentifierObmOK() *GetNodesIdentifierObmOK {
 obm settings
 */
 type GetNodesIdentifierObmOK struct {
-	Payload GetNodesIdentifierObmOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierObmOK) Error() string {
@@ -140,9 +140,3 @@ func (o *GetNodesIdentifierObmDefault) readResponse(response runtime.ClientRespo
 
 	return nil
 }
-
-/*GetNodesIdentifierObmOKBodyBody get nodes identifier obm o k body body
-
-swagger:model GetNodesIdentifierObmOKBodyBody
-*/
-type GetNodesIdentifierObmOKBodyBody interface{}

--- a/client/obms/get_obms_library_responses.go
+++ b/client/obms/get_obms_library_responses.go
@@ -50,7 +50,7 @@ get list of possible OBM services
 
 */
 type GetObmsLibraryOK struct {
-	Payload GetObmsLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetObmsLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetObmsLibraryDefault) readResponse(response runtime.ClientResponse, co
 
 	return nil
 }
-
-/*GetObmsLibraryOKBodyBody get obms library o k body body
-
-swagger:model GetObmsLibraryOKBodyBody
-*/
-type GetObmsLibraryOKBodyBody interface{}

--- a/client/pollers/get_nodes_identifier_pollers_responses.go
+++ b/client/pollers/get_nodes_identifier_pollers_responses.go
@@ -57,7 +57,7 @@ all pollers of specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierPollersOK struct {
-	Payload GetNodesIdentifierPollersOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierPollersOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierPollersDefault) readResponse(response runtime.ClientR
 
 	return nil
 }
-
-/*GetNodesIdentifierPollersOKBodyBody get nodes identifier pollers o k body body
-
-swagger:model GetNodesIdentifierPollersOKBodyBody
-*/
-type GetNodesIdentifierPollersOKBodyBody interface{}

--- a/client/pollers/get_pollers_library_responses.go
+++ b/client/pollers/get_pollers_library_responses.go
@@ -50,7 +50,7 @@ list of all pollers
 
 */
 type GetPollersLibraryOK struct {
-	Payload GetPollersLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetPollersLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetPollersLibraryDefault) readResponse(response runtime.ClientResponse,
 
 	return nil
 }
-
-/*GetPollersLibraryOKBodyBody get pollers library o k body body
-
-swagger:model GetPollersLibraryOKBodyBody
-*/
-type GetPollersLibraryOKBodyBody interface{}

--- a/client/pollers/get_pollers_responses.go
+++ b/client/pollers/get_pollers_responses.go
@@ -50,7 +50,7 @@ list of all pollers
 
 */
 type GetPollersOK struct {
-	Payload GetPollersOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetPollersOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetPollersDefault) readResponse(response runtime.ClientResponse, consum
 
 	return nil
 }
-
-/*GetPollersOKBodyBody get pollers o k body body
-
-swagger:model GetPollersOKBodyBody
-*/
-type GetPollersOKBodyBody interface{}

--- a/client/post/post_client.go
+++ b/client/post/post_client.go
@@ -289,7 +289,7 @@ PutFilesFileidentifier puts file based on filename
 Put file based on filename, returns the uuid of the stored file.
 
 */
-func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierCreated, error) {
+func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutFilesFileidentifierParams()
@@ -309,7 +309,7 @@ func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, au
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PutFilesFileidentifierCreated), nil
+	return result.(*PutFilesFileidentifierOK), nil
 }
 
 // SetTransport changes the transport on the client

--- a/client/profiles/get_profiles_library_responses.go
+++ b/client/profiles/get_profiles_library_responses.go
@@ -50,7 +50,7 @@ list of possible profiles
 
 */
 type GetProfilesLibraryOK struct {
-	Payload GetProfilesLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetProfilesLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetProfilesLibraryDefault) readResponse(response runtime.ClientResponse
 
 	return nil
 }
-
-/*GetProfilesLibraryOKBodyBody get profiles library o k body body
-
-swagger:model GetProfilesLibraryOKBodyBody
-*/
-type GetProfilesLibraryOKBodyBody interface{}

--- a/client/skus/get_skus_identifier_nodes_responses.go
+++ b/client/skus/get_skus_identifier_nodes_responses.go
@@ -57,7 +57,7 @@ return nodes associated with that sku
 
 */
 type GetSkusIdentifierNodesOK struct {
-	Payload GetSkusIdentifierNodesOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetSkusIdentifierNodesOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetSkusIdentifierNodesDefault) readResponse(response runtime.ClientResp
 
 	return nil
 }
-
-/*GetSkusIdentifierNodesOKBodyBody get skus identifier nodes o k body body
-
-swagger:model GetSkusIdentifierNodesOKBodyBody
-*/
-type GetSkusIdentifierNodesOKBodyBody interface{}

--- a/client/skus/get_skus_responses.go
+++ b/client/skus/get_skus_responses.go
@@ -50,7 +50,7 @@ list of skus
 
 */
 type GetSkusOK struct {
-	Payload GetSkusOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetSkusOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetSkusDefault) readResponse(response runtime.ClientResponse, consumer 
 
 	return nil
 }
-
-/*GetSkusOKBodyBody get skus o k body body
-
-swagger:model GetSkusOKBodyBody
-*/
-type GetSkusOKBodyBody interface{}

--- a/client/task/get_workflows_tasks_responses.go
+++ b/client/task/get_workflows_tasks_responses.go
@@ -50,7 +50,7 @@ Fetch tasks from task library
 
 */
 type GetWorkflowsTasksOK struct {
-	Payload GetWorkflowsTasksOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsTasksOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsTasksDefault) readResponse(response runtime.ClientResponse,
 
 	return nil
 }
-
-/*GetWorkflowsTasksOKBodyBody get workflows tasks o k body body
-
-swagger:model GetWorkflowsTasksOKBodyBody
-*/
-type GetWorkflowsTasksOKBodyBody interface{}

--- a/client/templates/get_templates_library_responses.go
+++ b/client/templates/get_templates_library_responses.go
@@ -50,7 +50,7 @@ list of possible templates
 
 */
 type GetTemplatesLibraryOK struct {
-	Payload GetTemplatesLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetTemplatesLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetTemplatesLibraryDefault) readResponse(response runtime.ClientRespons
 
 	return nil
 }
-
-/*GetTemplatesLibraryOKBodyBody get templates library o k body body
-
-swagger:model GetTemplatesLibraryOKBodyBody
-*/
-type GetTemplatesLibraryOKBodyBody interface{}

--- a/client/workflow/get_nodes_identifier_workflows_responses.go
+++ b/client/workflow/get_nodes_identifier_workflows_responses.go
@@ -57,7 +57,7 @@ all workflows for specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierWorkflowsOK struct {
-	Payload GetNodesIdentifierWorkflowsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetNodesIdentifierWorkflowsOK) Error() string {
@@ -141,9 +141,3 @@ func (o *GetNodesIdentifierWorkflowsDefault) readResponse(response runtime.Clien
 
 	return nil
 }
-
-/*GetNodesIdentifierWorkflowsOKBodyBody get nodes identifier workflows o k body body
-
-swagger:model GetNodesIdentifierWorkflowsOKBodyBody
-*/
-type GetNodesIdentifierWorkflowsOKBodyBody interface{}

--- a/client/workflow/get_workflows_library_injectable_name_responses.go
+++ b/client/workflow/get_workflows_library_injectable_name_responses.go
@@ -48,7 +48,7 @@ List all workflows available to run
 
 */
 type GetWorkflowsLibraryInjectableNameOK struct {
-	Payload GetWorkflowsLibraryInjectableNameOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsLibraryInjectableNameOK) Error() string {
@@ -100,12 +100,6 @@ func (o *GetWorkflowsLibraryInjectableNameDefault) readResponse(response runtime
 
 	return nil
 }
-
-/*GetWorkflowsLibraryInjectableNameOKBodyBody get workflows library injectable name o k body body
-
-swagger:model GetWorkflowsLibraryInjectableNameOKBodyBody
-*/
-type GetWorkflowsLibraryInjectableNameOKBodyBody interface{}
 
 /*GetWorkflowsLibraryInjectableNameDefaultBodyBody get workflows library injectable name default body body
 

--- a/client/workflow/get_workflows_library_responses.go
+++ b/client/workflow/get_workflows_library_responses.go
@@ -50,7 +50,7 @@ List all workflows available to run
 
 */
 type GetWorkflowsLibraryOK struct {
-	Payload GetWorkflowsLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsLibraryDefault) readResponse(response runtime.ClientRespons
 
 	return nil
 }
-
-/*GetWorkflowsLibraryOKBodyBody get workflows library o k body body
-
-swagger:model GetWorkflowsLibraryOKBodyBody
-*/
-type GetWorkflowsLibraryOKBodyBody interface{}

--- a/client/workflow/get_workflows_responses.go
+++ b/client/workflow/get_workflows_responses.go
@@ -50,7 +50,7 @@ Fetch workflows
 
 */
 type GetWorkflowsOK struct {
-	Payload GetWorkflowsOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsDefault) readResponse(response runtime.ClientResponse, cons
 
 	return nil
 }
-
-/*GetWorkflowsOKBodyBody get workflows o k body body
-
-swagger:model GetWorkflowsOKBodyBody
-*/
-type GetWorkflowsOKBodyBody interface{}

--- a/client/workflow/get_workflows_tasks_library_responses.go
+++ b/client/workflow/get_workflows_tasks_library_responses.go
@@ -50,7 +50,7 @@ List workflow tasks library
 
 */
 type GetWorkflowsTasksLibraryOK struct {
-	Payload GetWorkflowsTasksLibraryOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsTasksLibraryOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsTasksLibraryDefault) readResponse(response runtime.ClientRe
 
 	return nil
 }
-
-/*GetWorkflowsTasksLibraryOKBodyBody get workflows tasks library o k body body
-
-swagger:model GetWorkflowsTasksLibraryOKBodyBody
-*/
-type GetWorkflowsTasksLibraryOKBodyBody interface{}

--- a/client/workflow/get_workflows_tasks_responses.go
+++ b/client/workflow/get_workflows_tasks_responses.go
@@ -50,7 +50,7 @@ Fetch tasks from task library
 
 */
 type GetWorkflowsTasksOK struct {
-	Payload GetWorkflowsTasksOKBodyBody
+	Payload []interface{}
 }
 
 func (o *GetWorkflowsTasksOK) Error() string {
@@ -104,9 +104,3 @@ func (o *GetWorkflowsTasksDefault) readResponse(response runtime.ClientResponse,
 
 	return nil
 }
-
-/*GetWorkflowsTasksOKBodyBody get workflows tasks o k body body
-
-swagger:model GetWorkflowsTasksOKBodyBody
-*/
-type GetWorkflowsTasksOKBodyBody interface{}

--- a/swagger-spec/monorail.yml
+++ b/swagger-spec/monorail.yml
@@ -9,7 +9,7 @@ schemes:
 basePath: /api/1.1
 produces:
   - application/json
-  # x-gzip explicitly for files once the bugs listed 
+  # x-gzip explicitly for files once the bugs listed
   #   in comments below are fixed by swagger team.
   - application/x-gzip
 consumes:
@@ -62,8 +62,8 @@ paths:
       responses:
         200:
           description: |
-            single library poller 
-          schema: 
+            single library poller
+          schema:
             type: object
         404:
           description: |
@@ -132,8 +132,8 @@ paths:
       responses:
         200:
           description: |
-            Specifics of the specified poller 
-          schema: 
+            Specifics of the specified poller
+          schema:
             type: object
         404:
           description: |
@@ -162,8 +162,8 @@ paths:
       responses:
         200:
           description: |
-            Specifics of the patched poller 
-          schema: 
+            Specifics of the patched poller
+          schema:
             type: object
         404:
           description: |
@@ -192,7 +192,7 @@ paths:
       responses:
         204:
           description: |
-            Poller delete successfully 
+            Poller delete successfully
         404:
           description: |
             There is no poller with specified identifier.
@@ -222,7 +222,7 @@ paths:
         200:
           description: |
             data for poller
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -274,7 +274,7 @@ paths:
         200:
           description: |
             single template
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -304,7 +304,7 @@ paths:
         200:
           description: |
             return template
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -372,7 +372,7 @@ paths:
         200:
           description: |
             sku to create
-          schema: 
+          schema:
             type: object
         500:
           description: |
@@ -403,7 +403,7 @@ paths:
         200:
           description: |
             return sku
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -433,7 +433,7 @@ paths:
         200:
           description: |
             sku to patch
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -468,7 +468,7 @@ paths:
         204:
           description: |
             return all skus
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -555,7 +555,7 @@ paths:
         200:
           description: |
             return profile
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -585,7 +585,7 @@ paths:
         200:
           description: |
             profile to put
-          schema: 
+          schema:
             type: object
         500:
           description: |
@@ -596,7 +596,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /obms/library:
     get:
       summary: |
@@ -638,18 +638,18 @@ paths:
         200:
           description: |
             return OBM service
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The obm service with the identifier was not found 
+            The obm service with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /workflows/library:
     get:
       summary: |
@@ -671,7 +671,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /workflows/library/{injectableName}:
     get:
       summary: |
@@ -762,12 +762,12 @@ paths:
         200:
           description: |
             Add tasks to task library
-          schema: 
+          schema:
             type: object
         500:
           description: |
             Error problem was encountered, task was not written.
-          schema: 
+          schema:
             $ref: '#/definitions/Error'
         default:
           description: Upload failed
@@ -792,7 +792,7 @@ paths:
         200:
           description: |
             Fetch workflows
-          schema: 
+          schema:
             type: object
         default:
           description: Unexpected error
@@ -838,18 +838,18 @@ paths:
         200:
           description: |
             Fetch workflows
-          schema: 
+          schema:
             type: object
         500:
           description: |
             Error problem was encountered, workflow was not written.
-          schema: 
+          schema:
             $ref: '#/definitions/Error'
         default:
           description: Upload failed
           schema:
             $ref: '#/definitions/Error'
-  
+
   /nodes/{identifier}/workflows/active:
     get:
       summary: |
@@ -872,11 +872,11 @@ paths:
         200:
           description: |
             Fetch currently running workflows for specified node
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -904,11 +904,11 @@ paths:
         200:
           description: |
             Canceled workflows for specified node
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -943,7 +943,7 @@ paths:
               type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -981,11 +981,11 @@ paths:
         200:
           description: |
             the workflow that was created
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -995,7 +995,7 @@ paths:
   /nodes/{macaddress}/dhcp/whitelist:
     post:
       summary: |
-        Add a whitelist of specified mac address 
+        Add a whitelist of specified mac address
       description: |
         Add a whitelist of specified mac address
       parameters:
@@ -1020,11 +1020,11 @@ paths:
         201:
           description: |
             the add was successful and it returns the whitelist
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -1055,14 +1055,14 @@ paths:
             delete completed successfully
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-    
+
   /nodes/{identifier}/pollers:
     get:
       summary: |
@@ -1091,14 +1091,14 @@ paths:
               type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /nodes/{identifier}/catalogs/{source}:
     get:
       summary: |
@@ -1128,11 +1128,11 @@ paths:
           description: |
             specific source catalog of specified node, |
             empty object if none exist.
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -1168,14 +1168,14 @@ paths:
               type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /nodes/{identifier}/obm/identify:
     get:
       summary: |
@@ -1198,7 +1198,7 @@ paths:
       responses:
         200:
           description: obm identity light settings
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -1227,7 +1227,7 @@ paths:
           description: |
             obm settings to apply.
           required: true
-          schema: 
+          schema:
             type: boolean
       tags:
         - nodes
@@ -1298,7 +1298,7 @@ paths:
           description: |
             obm settings to apply.
           required: true
-          schema: 
+          schema:
             type: object
       tags:
         - nodes
@@ -1434,7 +1434,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         404:
           description: The node with the identifier was not found.
@@ -1489,7 +1489,7 @@ paths:
           description: |
             object patches to apply.
           required: true
-          schema: 
+          schema:
             type: object
       tags:
         - nodes
@@ -1521,7 +1521,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         400:
           description: invalidAttributes - 1 attribute is invalid
@@ -1577,7 +1577,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1627,7 +1627,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1652,7 +1652,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1684,7 +1684,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1735,8 +1735,8 @@ paths:
         - files
         - get
       responses:
-# https://github.com/swagger-api/swagger-spec/issues/260 means we can't 
-# describe the return of a file easily today until jsonspec and swagger 
+# https://github.com/swagger-api/swagger-spec/issues/260 means we can't
+# describe the return of a file easily today until jsonspec and swagger
 # are "fixed"
         200:
           description: The file requested

--- a/swagger-spec/monorail.yml
+++ b/swagger-spec/monorail.yml
@@ -36,7 +36,9 @@ paths:
           description: |
             list of all pollers
           schema:
-            type: object
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -86,7 +88,9 @@ paths:
           description: |
             list of all pollers
           schema:
-            type: object
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -243,7 +247,9 @@ paths:
           description: |
             list of possible templates
           schema:
-            type: object
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -346,8 +352,10 @@ paths:
         200:
           description: |
              list of skus
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -492,8 +500,10 @@ paths:
         200:
           description: |
             return nodes associated with that sku
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             There is no sku with identifier.
@@ -517,8 +527,10 @@ paths:
         200:
           description: |
             list of possible profiles
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -598,8 +610,10 @@ paths:
         200:
           description: |
             get list of possible OBM services
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -649,8 +663,10 @@ paths:
         200:
           description: |
             List all workflows available to run
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -674,8 +690,10 @@ paths:
         200:
           description: |
             List all workflows available to run
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -694,8 +712,10 @@ paths:
         200:
           description: |
             List workflow tasks library
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -715,8 +735,10 @@ paths:
         200:
           description: |
             Fetch tasks from task library
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -790,8 +812,10 @@ paths:
         200:
           description: |
             Fetch workflows
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -913,8 +937,10 @@ paths:
         200:
           description: |
             all workflows for specified node, empty object if none exist.
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found 
@@ -1059,8 +1085,10 @@ paths:
         200:
           description: |
             all pollers of specified node, empty object if none exist.
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found 
@@ -1134,8 +1162,10 @@ paths:
         200:
           description: |
             all catalogs of specified node, empty object if none exist.
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found 
@@ -1237,8 +1267,10 @@ paths:
       responses:
         200:
           description: obm settings
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found or has no obm settings.
@@ -1802,7 +1834,7 @@ paths:
         - get
       responses:
         200:
-          description: An array of configuration objects
+          description: Configuration object
           schema:
             type: object
         default:
@@ -1879,9 +1911,7 @@ paths:
         200:
           description: A single catalog
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/catalog'
+            $ref: '#/definitions/catalog'
         default:
           description: NotFound error
   /dhcp:
@@ -1922,9 +1952,7 @@ paths:
         200:
           description: A single lease
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/lease'
+            $ref: '#/definitions/lease'
         default:
           description: NotFound error
     delete:


### PR DESCRIPTION
Matching PR to RachHD is here: https://github.com/RackHD/on-http/pull/292

Many of the GET schemas are wrong, listing the return as a generic object instead of a list of objects.  Fix that.

Also, remove all the extra whitespace from `monorail.yml` in a separate commit.

**Probably want to merge #15 first**, and then I can rebase this one on top of it. But it can be reviewed as-is.
