### PR TITLE
Fix tests by fixing import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@ import (
     "log"
     "os"
 
-    //swagclient "github.com/go-swagger/go-swagger/client"
-    httptransport "github.com/go-swagger/go-swagger/httpkit/client"
-    "github.com/go-swagger/go-swagger/strfmt"
+    httptransport "github.com/go-openapi/runtime/client"
+    "github.com/go-openapi/strfmt"
 
     apiclient "github.com/emccode/gorackhd/client"
     "github.com/emccode/gorackhd/client/nodes"

--- a/gorackhd_test.go
+++ b/gorackhd_test.go
@@ -7,9 +7,8 @@ import (
 	"os"
 	"testing"
 
-	//swagclient "github.com/go-swagger/go-swagger/client"
-	httptransport "github.com/go-swagger/go-swagger/httpkit/client"
-	"github.com/go-swagger/go-swagger/strfmt"
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
 
 	apiclient "github.com/emccode/gorackhd/client"
 	"github.com/emccode/gorackhd/client/lookups"


### PR DESCRIPTION
@kacole2 This will fix the problems you saw from #15 

I'm guessing this changed somewhere along the way, but strfmt and the http transport come from go-openapi, not go-swagger.  I wonder if they moved it between packages or something?  When I first started `rackhdcli`, I hit this same thing. Sorry I didn't catch this was still in your package.
