### PR TITLE
Return to using vendored go-swagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-glide.lock
 .go.get
-swagger
 vendor/
 
 # Compiled source #

--- a/Makefile
+++ b/Makefile
@@ -1,66 +1,37 @@
 export GO15VENDOREXPERIMENT=1
 
 GLIDE := $(GOPATH)/bin/glide
-GLIDE_YAML := glide.yaml
 GLIDE_LOCK := glide.lock
-GLIDE_SWAGGER_YAML := glide-swagger.yaml
-GO_GET := .go.get
-SWAGGER := $(GOPATH)/bin/swagger
 SWAGGER_PKG := github.com/go-swagger/go-swagger
-SWAGGER_CMD_SRC := $(SWAGGER_PKG)/cmd/swagger/swagger.go
-GOPATH_SWAGGER_CMD_SRC := $(GOPATH)/src/$(SWAGGER_CMD_SRC)
-VENDORED_SWAGGER_CMD_SRC := vendor/$(SWAGGER_CMD_SRC)
+SWAGGER_CMD := $(SWAGGER_PKG)/cmd/swagger/swagger.go
+VENDORED_SWAGGER_CMD := vendor/$(SWAGGER_CMD)
 SPEC_FILE := swagger-spec/monorail.yml
 CLIENT := client
 MODELS := models
 CLIENT_BINDINGS := $(CLIENT)/monorail_client.go
-GOCOV := $(GOPATH)/bin/gocov
-GOVERALLS := $(GOPATH)/bin/goveralls
-COVER := $(GOPATH)/bin/cover
-COVER_OUT := cover.out
 
 all: install
-
-deps: $(CLIENT_BINDINGS) $(GO_GET)
-
-$(GO_GET): | $(GLIDE_LOCK)
-	go get -d $$($(GLIDE) nv) && touch $@
-
-$(GLIDE_LOCK): $(GLIDE_YAML) | $(GLIDE) $(CLIENT_BINDINGS)
-	$(GLIDE) --home $(HOME) up
 
 $(GLIDE):
 	go get -u github.com/Masterminds/glide
 
-$(GOPATH_SWAGGER_CMD_SRC): $(VENDORED_SWAGGER_CMD_SRC)
-$(VENDORED_SWAGGER_CMD_SRC): $(GLIDE_SWAGGER_YAML) | $(GLIDE)
-	$(GLIDE) --home $(HOME) --yaml $< up --quick --cache-gopath --use-gopath
+swagger_deps: $(GLIDE_LOCK) | $(GLIDE)
+	$(GLIDE) --home $(HOME) install
 
-client-bindings: $(CLIENT_BINDINGS)
-$(CLIENT_BINDINGS): $(VENDORED_SWAGGER_CMD_SRC) $(GOPATH_SWAGGER_CMD_SRC) $(SPEC_FILE)
-	go run $(GOPATH_SWAGGER_CMD_SRC) generate client -f $(SPEC_FILE)
+$(CLIENT_BINDINGS): swagger_deps $(SPEC_FILE)
+	go run $(VENDORED_SWAGGER_CMD) generate client -f $(SPEC_FILE)
 
-install: $(CLIENT_BINDINGS) $(GO_GET)
+install: $(CLIENT_BINDINGS)
 	go install -v $$($(GLIDE) nv)
 
-test: $(COVER_OUT)
-$(COVER_OUT):
-	go test -v $$($(GLIDE) nv) -cover -coverprofile $@
-
-cover: $(COVER_OUT) | $(GOCOV) $(GOVERALLS) $(COVER)
-	$(GOVERALLS) -coverprofile=$<
+test:
+	go test -v
 
 clean:
-	rm -fr $(GLIDE_LOCK) $(GO_GET) $(COVER_OUT) $(CLIENT) $(MODELS)
+	rm -fr $(COVER_OUT) $(CLIENT) $(MODELS)
 
 clobber: clean
 	rm -fr vendor
 
-clobber-gopath-swagger:
-	rm -fr $(SWAGGER)
-	rm -fr $(GOPATH)/src/$(SWAGGER_PKG)
-	rm -fr $(GOPATH)/pkg/*/$(SWAGGER_PKG)
-
-.PHONY: all deps install test cover \
-		clean clobber clobber-gopath-swagger \
-		client-bindings
+.PHONY: all swagger_deps install test \
+	clean clobber

--- a/client/post/post_client.go
+++ b/client/post/post_client.go
@@ -318,7 +318,7 @@ PutFilesFileidentifier puts file based on filename
 Put file based on filename, returns the uuid of the stored file.
 
 */
-func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierOK, error) {
+func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutFilesFileidentifierParams()
@@ -338,7 +338,7 @@ func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, au
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PutFilesFileidentifierOK), nil
+	return result.(*PutFilesFileidentifierCreated), nil
 }
 
 // SetTransport changes the transport on the client

--- a/glide-swagger.yaml
+++ b/glide-swagger.yaml
@@ -1,8 +1,0 @@
-package: github.com/emccode/gorackhd
-ignore:
-- client
-- models
-import:
-  - package: github.com/go-swagger/go-swagger
-    ref:     6b712512cbe1f1a4882354856b57c61d760499cc
-    vcs:     git

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,53 @@
+hash: 70287950b3bbe43c249f1c4e01ea98063a462e8f4c9dd751b3bab3018e4b03c2
+updated: 2016-08-15T13:28:23.592271813-07:00
+imports:
+- name: github.com/asaskevich/govalidator
+  version: df81827fdd59d8b4fb93d8910b286ab7a3919520
+  repo: https://github.com/asaskevich/govalidator
+- name: github.com/go-openapi/analysis
+  version: 5a8fe2138f95138797c306c07e65e759c55f898f
+  repo: https://github.com/go-openapi/analysis
+- name: github.com/go-openapi/errors
+  version: 8a4ac38004d8cdb96dac7bece88034dd3d94493f
+  repo: https://github.com/go-openapi/errors
+- name: github.com/go-openapi/jsonpointer
+  version: f5133566e18f23f2085d953998fd72959b698623
+  repo: https://github.com/go-openapi/jsonpointer
+- name: github.com/go-openapi/jsonreference
+  version: 44d0c05f81b60f99eeb8c188b8983ec82e5d872f
+  repo: https://github.com/go-openapi/jsonreference
+- name: github.com/go-openapi/loads
+  version: 3a4490f96e6ea1ba7d66602e70ffca0fc26aa6ca
+  repo: https://github.com/go-openapi/loads
+- name: github.com/go-openapi/runtime
+  version: b12d766cb7ccfdac98c946f9f0ab4afa8c6aeadc
+  subpackages:
+  - client
+- name: github.com/go-openapi/spec
+  version: 2029f5179022b7e840b71a663b1fda7fb24e49a0
+  repo: https://github.com/go-openapi/spec
+- name: github.com/go-openapi/strfmt
+  version: 66a99d45c3043d45d346b1c8db5dc2f76a004869
+  repo: https://github.com/go-openapi/strfmt
+- name: github.com/go-openapi/swag
+  version: f8ab07bb33bb43a743eb65daf0588ab522e5160f
+  repo: https://github.com/go-openapi/swag
+- name: github.com/go-openapi/validate
+  version: 14872542e3bd537d6d6b9976e066ff658d41975f
+- name: github.com/go-swagger/go-swagger
+  version: fade7c68fe6ea117733051b041c590569c428d67
+  vcs: git
+- name: github.com/opennota/urlesc
+  version: 5fa9ff0392746aeae1c4b37fcc42c65afa7a9587
+  repo: https://github.com/opennota/urlesc
+- name: github.com/PuerkitoBio/purell
+  version: d69616f51cdfcd7514d6a380847a152dfc2a749d
+  repo: https://github.com/PuerkitoBio/purell
+- name: golang.org/x/net
+  version: 0c607074acd38c5f23d1344dfe74c977464d1257
+  repo: https://go.googlesource.com/net
+  subpackages:
+  - context
+  - netutil
+  - context/ctxhttp
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,5 @@
 package: github.com/emccode/gorackhd
 import:
   - package: github.com/go-swagger/go-swagger
-    ref:     6b712512cbe1f1a4882354856b57c61d760499cc
+    version: 0.5.9
     vcs:     git


### PR DESCRIPTION
Closes #19 

The Makefile is using go-swagger out of $GOPATH instead of out the
vendor/ directory. gorackhd is supposed to use everything out
of vendor/, so there's no reason to reference a GOPATH'd version
of go-swagger in the Makefile at all.

We had unknowing been using newer versions of go-swagger to generate
client code, so this builds on top of that by just setting the version
to 0.5.9, which is pre-release of 0.6.0. Alternative would be to set
version to 0.5.0 and go with that, but let's move on to the future!

We also start checking in glide.lock so our deps are locked. The
behavior to date has been that even when locking down go-swagger to
0.5.9, regenerating the client lib has produced different files at
times -- presumably because of changing deps. This will allow us to
have truly versioned releases of gorackhd.

The test target has also been simplified by removing the cover
pieces. The existing code through errors about not producing a cover
profile on mulitiple packages. This functionality is not currently
being used, so remove it for now.
