### PR TITLE
Use existing object definitions for responses

### DIFF
--- a/client/get/get_client.go
+++ b/client/get/get_client.go
@@ -315,9 +315,9 @@ func (a *Client) GetNodes(params *GetNodesParams, authInfo runtime.ClientAuthInf
 }
 
 /*
-GetNodesIdentifier lists of all nodes or if there are none an empty object
+GetNodesIdentifier thes node by identifier
 
-List of all nodes or if there are none an empty object
+The node by identifier
 
 */
 func (a *Client) GetNodesIdentifier(params *GetNodesIdentifierParams, authInfo runtime.ClientAuthInfoWriter) (*GetNodesIdentifierOK, error) {
@@ -1127,9 +1127,9 @@ func (a *Client) GetWorkflowsLibrary(params *GetWorkflowsLibraryParams, authInfo
 }
 
 /*
-GetWorkflowsLibraryInjectableName lists all workflows available to run
+GetWorkflowsLibraryInjectableName fetches workflow by injectable name
 
-List all workflows available to run
+Fetch workflow by injectable name
 
 */
 func (a *Client) GetWorkflowsLibraryInjectableName(params *GetWorkflowsLibraryInjectableNameParams, authInfo runtime.ClientAuthInfoWriter) (*GetWorkflowsLibraryInjectableNameOK, error) {

--- a/client/get/get_nodes_identifier_responses.go
+++ b/client/get/get_nodes_identifier_responses.go
@@ -53,10 +53,10 @@ func NewGetNodesIdentifierOK() *GetNodesIdentifierOK {
 
 /*GetNodesIdentifierOK handles this case with default header values.
 
-array of all
+The node
 */
 type GetNodesIdentifierOK struct {
-	Payload []interface{}
+	Payload *models.Node
 }
 
 func (o *GetNodesIdentifierOK) Error() string {
@@ -65,8 +65,10 @@ func (o *GetNodesIdentifierOK) Error() string {
 
 func (o *GetNodesIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Node)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/client/get/get_nodes_identifier_workflows_responses.go
+++ b/client/get/get_nodes_identifier_workflows_responses.go
@@ -57,7 +57,7 @@ all workflows for specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierWorkflowsOK struct {
-	Payload []interface{}
+	Payload []*models.Graphobject
 }
 
 func (o *GetNodesIdentifierWorkflowsOK) Error() string {

--- a/client/get/get_nodes_responses.go
+++ b/client/get/get_nodes_responses.go
@@ -56,7 +56,7 @@ func NewGetNodesOK() *GetNodesOK {
 array of all
 */
 type GetNodesOK struct {
-	Payload []interface{}
+	Payload []*models.Node
 }
 
 func (o *GetNodesOK) Error() string {

--- a/client/get/get_skus_identifier_nodes_responses.go
+++ b/client/get/get_skus_identifier_nodes_responses.go
@@ -57,7 +57,7 @@ return nodes associated with that sku
 
 */
 type GetSkusIdentifierNodesOK struct {
-	Payload []interface{}
+	Payload []*models.Node
 }
 
 func (o *GetSkusIdentifierNodesOK) Error() string {

--- a/client/get/get_skus_identifier_responses.go
+++ b/client/get/get_skus_identifier_responses.go
@@ -57,7 +57,7 @@ return sku
 
 */
 type GetSkusIdentifierOK struct {
-	Payload GetSkusIdentifierOKBodyBody
+	Payload *models.Sku
 }
 
 func (o *GetSkusIdentifierOK) Error() string {
@@ -66,8 +66,10 @@ func (o *GetSkusIdentifierOK) Error() string {
 
 func (o *GetSkusIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Sku)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -141,9 +143,3 @@ func (o *GetSkusIdentifierDefault) readResponse(response runtime.ClientResponse,
 
 	return nil
 }
-
-/*GetSkusIdentifierOKBodyBody get skus identifier o k body body
-
-swagger:model GetSkusIdentifierOKBodyBody
-*/
-type GetSkusIdentifierOKBodyBody interface{}

--- a/client/get/get_skus_responses.go
+++ b/client/get/get_skus_responses.go
@@ -50,7 +50,7 @@ list of skus
 
 */
 type GetSkusOK struct {
-	Payload []interface{}
+	Payload []*models.Sku
 }
 
 func (o *GetSkusOK) Error() string {

--- a/client/get/get_tags_responses.go
+++ b/client/get/get_tags_responses.go
@@ -49,7 +49,7 @@ func NewGetTagsOK() *GetTagsOK {
 array of all tags fetched
 */
 type GetTagsOK struct {
-	Payload []interface{}
+	Payload []*models.Tag
 }
 
 func (o *GetTagsOK) Error() string {

--- a/client/get/get_workflows_instance_id_responses.go
+++ b/client/get/get_workflows_instance_id_responses.go
@@ -50,7 +50,7 @@ Fetch workflows
 
 */
 type GetWorkflowsInstanceIDOK struct {
-	Payload GetWorkflowsInstanceIDOKBodyBody
+	Payload *models.Graphobject
 }
 
 func (o *GetWorkflowsInstanceIDOK) Error() string {
@@ -59,8 +59,10 @@ func (o *GetWorkflowsInstanceIDOK) Error() string {
 
 func (o *GetWorkflowsInstanceIDOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Graphobject)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -104,9 +106,3 @@ func (o *GetWorkflowsInstanceIDDefault) readResponse(response runtime.ClientResp
 
 	return nil
 }
-
-/*GetWorkflowsInstanceIDOKBodyBody get workflows instance ID o k body body
-
-swagger:model GetWorkflowsInstanceIDOKBodyBody
-*/
-type GetWorkflowsInstanceIDOKBodyBody interface{}

--- a/client/get/get_workflows_library_injectable_name_responses.go
+++ b/client/get/get_workflows_library_injectable_name_responses.go
@@ -46,11 +46,11 @@ func NewGetWorkflowsLibraryInjectableNameOK() *GetWorkflowsLibraryInjectableName
 
 /*GetWorkflowsLibraryInjectableNameOK handles this case with default header values.
 
-List all workflows available to run
+Fetch workflow by injectable name
 
 */
 type GetWorkflowsLibraryInjectableNameOK struct {
-	Payload []interface{}
+	Payload GetWorkflowsLibraryInjectableNameOKBodyBody
 }
 
 func (o *GetWorkflowsLibraryInjectableNameOK) Error() string {
@@ -104,3 +104,9 @@ func (o *GetWorkflowsLibraryInjectableNameDefault) readResponse(response runtime
 
 	return nil
 }
+
+/*GetWorkflowsLibraryInjectableNameOKBodyBody get workflows library injectable name o k body body
+
+swagger:model GetWorkflowsLibraryInjectableNameOKBodyBody
+*/
+type GetWorkflowsLibraryInjectableNameOKBodyBody interface{}

--- a/client/get/get_workflows_responses.go
+++ b/client/get/get_workflows_responses.go
@@ -50,7 +50,7 @@ Fetch workflows
 
 */
 type GetWorkflowsOK struct {
-	Payload []interface{}
+	Payload []*models.Graphobject
 }
 
 func (o *GetWorkflowsOK) Error() string {

--- a/client/monorail_client.go
+++ b/client/monorail_client.go
@@ -43,7 +43,7 @@ func NewHTTPClient(formats strfmt.Registry) *Monorail {
 	if formats == nil {
 		formats = strfmt.Default
 	}
-	transport := httptransport.New("localhost", "/api/1.1", []string{"https", "http"})
+	transport := httptransport.New("localhost", "/api/1.1", []string{"http", "https"})
 	return New(transport, formats)
 }
 

--- a/client/nodes/get_nodes_identifier_responses.go
+++ b/client/nodes/get_nodes_identifier_responses.go
@@ -53,10 +53,10 @@ func NewGetNodesIdentifierOK() *GetNodesIdentifierOK {
 
 /*GetNodesIdentifierOK handles this case with default header values.
 
-array of all
+The node
 */
 type GetNodesIdentifierOK struct {
-	Payload []interface{}
+	Payload *models.Node
 }
 
 func (o *GetNodesIdentifierOK) Error() string {
@@ -65,8 +65,10 @@ func (o *GetNodesIdentifierOK) Error() string {
 
 func (o *GetNodesIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Node)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/client/nodes/get_nodes_identifier_workflows_responses.go
+++ b/client/nodes/get_nodes_identifier_workflows_responses.go
@@ -57,7 +57,7 @@ all workflows for specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierWorkflowsOK struct {
-	Payload []interface{}
+	Payload []*models.Graphobject
 }
 
 func (o *GetNodesIdentifierWorkflowsOK) Error() string {

--- a/client/nodes/get_nodes_responses.go
+++ b/client/nodes/get_nodes_responses.go
@@ -56,7 +56,7 @@ func NewGetNodesOK() *GetNodesOK {
 array of all
 */
 type GetNodesOK struct {
-	Payload []interface{}
+	Payload []*models.Node
 }
 
 func (o *GetNodesOK) Error() string {

--- a/client/nodes/get_skus_identifier_nodes_responses.go
+++ b/client/nodes/get_skus_identifier_nodes_responses.go
@@ -57,7 +57,7 @@ return nodes associated with that sku
 
 */
 type GetSkusIdentifierNodesOK struct {
-	Payload []interface{}
+	Payload []*models.Node
 }
 
 func (o *GetSkusIdentifierNodesOK) Error() string {

--- a/client/nodes/nodes_client.go
+++ b/client/nodes/nodes_client.go
@@ -168,9 +168,9 @@ func (a *Client) GetNodes(params *GetNodesParams, authInfo runtime.ClientAuthInf
 }
 
 /*
-GetNodesIdentifier lists of all nodes or if there are none an empty object
+GetNodesIdentifier thes node by identifier
 
-List of all nodes or if there are none an empty object
+The node by identifier
 
 */
 func (a *Client) GetNodesIdentifier(params *GetNodesIdentifierParams, authInfo runtime.ClientAuthInfoWriter) (*GetNodesIdentifierOK, error) {

--- a/client/nodes/patch_nodes_identifier_responses.go
+++ b/client/nodes/patch_nodes_identifier_responses.go
@@ -56,7 +56,7 @@ func NewPatchNodesIdentifierOK() *PatchNodesIdentifierOK {
 patch succeeded
 */
 type PatchNodesIdentifierOK struct {
-	Payload PatchNodesIdentifierOKBodyBody
+	Payload *models.Node
 }
 
 func (o *PatchNodesIdentifierOK) Error() string {
@@ -65,8 +65,10 @@ func (o *PatchNodesIdentifierOK) Error() string {
 
 func (o *PatchNodesIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Node)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -139,9 +141,3 @@ func (o *PatchNodesIdentifierDefault) readResponse(response runtime.ClientRespon
 
 	return nil
 }
-
-/*PatchNodesIdentifierOKBodyBody patch nodes identifier o k body body
-
-swagger:model PatchNodesIdentifierOKBodyBody
-*/
-type PatchNodesIdentifierOKBodyBody interface{}

--- a/client/patch/patch_nodes_identifier_responses.go
+++ b/client/patch/patch_nodes_identifier_responses.go
@@ -56,7 +56,7 @@ func NewPatchNodesIdentifierOK() *PatchNodesIdentifierOK {
 patch succeeded
 */
 type PatchNodesIdentifierOK struct {
-	Payload PatchNodesIdentifierOKBodyBody
+	Payload *models.Node
 }
 
 func (o *PatchNodesIdentifierOK) Error() string {
@@ -65,8 +65,10 @@ func (o *PatchNodesIdentifierOK) Error() string {
 
 func (o *PatchNodesIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Node)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -139,9 +141,3 @@ func (o *PatchNodesIdentifierDefault) readResponse(response runtime.ClientRespon
 
 	return nil
 }
-
-/*PatchNodesIdentifierOKBodyBody patch nodes identifier o k body body
-
-swagger:model PatchNodesIdentifierOKBodyBody
-*/
-type PatchNodesIdentifierOKBodyBody interface{}

--- a/client/patch/patch_skus_identifier_responses.go
+++ b/client/patch/patch_skus_identifier_responses.go
@@ -64,7 +64,7 @@ sku to patch
 
 */
 type PatchSkusIdentifierOK struct {
-	Payload PatchSkusIdentifierOKBodyBody
+	Payload *models.Sku
 }
 
 func (o *PatchSkusIdentifierOK) Error() string {
@@ -73,8 +73,10 @@ func (o *PatchSkusIdentifierOK) Error() string {
 
 func (o *PatchSkusIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Sku)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -178,9 +180,3 @@ func (o *PatchSkusIdentifierDefault) readResponse(response runtime.ClientRespons
 
 	return nil
 }
-
-/*PatchSkusIdentifierOKBodyBody patch skus identifier o k body body
-
-swagger:model PatchSkusIdentifierOKBodyBody
-*/
-type PatchSkusIdentifierOKBodyBody interface{}

--- a/client/skus/get_skus_identifier_nodes_responses.go
+++ b/client/skus/get_skus_identifier_nodes_responses.go
@@ -57,7 +57,7 @@ return nodes associated with that sku
 
 */
 type GetSkusIdentifierNodesOK struct {
-	Payload []interface{}
+	Payload []*models.Node
 }
 
 func (o *GetSkusIdentifierNodesOK) Error() string {

--- a/client/skus/get_skus_identifier_responses.go
+++ b/client/skus/get_skus_identifier_responses.go
@@ -57,7 +57,7 @@ return sku
 
 */
 type GetSkusIdentifierOK struct {
-	Payload GetSkusIdentifierOKBodyBody
+	Payload *models.Sku
 }
 
 func (o *GetSkusIdentifierOK) Error() string {
@@ -66,8 +66,10 @@ func (o *GetSkusIdentifierOK) Error() string {
 
 func (o *GetSkusIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Sku)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -141,9 +143,3 @@ func (o *GetSkusIdentifierDefault) readResponse(response runtime.ClientResponse,
 
 	return nil
 }
-
-/*GetSkusIdentifierOKBodyBody get skus identifier o k body body
-
-swagger:model GetSkusIdentifierOKBodyBody
-*/
-type GetSkusIdentifierOKBodyBody interface{}

--- a/client/skus/get_skus_responses.go
+++ b/client/skus/get_skus_responses.go
@@ -50,7 +50,7 @@ list of skus
 
 */
 type GetSkusOK struct {
-	Payload []interface{}
+	Payload []*models.Sku
 }
 
 func (o *GetSkusOK) Error() string {

--- a/client/skus/patch_skus_identifier_responses.go
+++ b/client/skus/patch_skus_identifier_responses.go
@@ -64,7 +64,7 @@ sku to patch
 
 */
 type PatchSkusIdentifierOK struct {
-	Payload PatchSkusIdentifierOKBodyBody
+	Payload *models.Sku
 }
 
 func (o *PatchSkusIdentifierOK) Error() string {
@@ -73,8 +73,10 @@ func (o *PatchSkusIdentifierOK) Error() string {
 
 func (o *PatchSkusIdentifierOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Sku)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -178,9 +180,3 @@ func (o *PatchSkusIdentifierDefault) readResponse(response runtime.ClientRespons
 
 	return nil
 }
-
-/*PatchSkusIdentifierOKBodyBody patch skus identifier o k body body
-
-swagger:model PatchSkusIdentifierOKBodyBody
-*/
-type PatchSkusIdentifierOKBodyBody interface{}

--- a/client/tags/get_tags_responses.go
+++ b/client/tags/get_tags_responses.go
@@ -49,7 +49,7 @@ func NewGetTagsOK() *GetTagsOK {
 array of all tags fetched
 */
 type GetTagsOK struct {
-	Payload []interface{}
+	Payload []*models.Tag
 }
 
 func (o *GetTagsOK) Error() string {

--- a/client/workflow/get_nodes_identifier_workflows_responses.go
+++ b/client/workflow/get_nodes_identifier_workflows_responses.go
@@ -57,7 +57,7 @@ all workflows for specified node, empty object if none exist.
 
 */
 type GetNodesIdentifierWorkflowsOK struct {
-	Payload []interface{}
+	Payload []*models.Graphobject
 }
 
 func (o *GetNodesIdentifierWorkflowsOK) Error() string {

--- a/client/workflow/get_workflows_instance_id_responses.go
+++ b/client/workflow/get_workflows_instance_id_responses.go
@@ -50,7 +50,7 @@ Fetch workflows
 
 */
 type GetWorkflowsInstanceIDOK struct {
-	Payload GetWorkflowsInstanceIDOKBodyBody
+	Payload *models.Graphobject
 }
 
 func (o *GetWorkflowsInstanceIDOK) Error() string {
@@ -59,8 +59,10 @@ func (o *GetWorkflowsInstanceIDOK) Error() string {
 
 func (o *GetWorkflowsInstanceIDOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(models.Graphobject)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -104,9 +106,3 @@ func (o *GetWorkflowsInstanceIDDefault) readResponse(response runtime.ClientResp
 
 	return nil
 }
-
-/*GetWorkflowsInstanceIDOKBodyBody get workflows instance ID o k body body
-
-swagger:model GetWorkflowsInstanceIDOKBodyBody
-*/
-type GetWorkflowsInstanceIDOKBodyBody interface{}

--- a/client/workflow/get_workflows_library_injectable_name_responses.go
+++ b/client/workflow/get_workflows_library_injectable_name_responses.go
@@ -46,11 +46,11 @@ func NewGetWorkflowsLibraryInjectableNameOK() *GetWorkflowsLibraryInjectableName
 
 /*GetWorkflowsLibraryInjectableNameOK handles this case with default header values.
 
-List all workflows available to run
+Fetch workflow by injectable name
 
 */
 type GetWorkflowsLibraryInjectableNameOK struct {
-	Payload []interface{}
+	Payload GetWorkflowsLibraryInjectableNameOKBodyBody
 }
 
 func (o *GetWorkflowsLibraryInjectableNameOK) Error() string {
@@ -104,3 +104,9 @@ func (o *GetWorkflowsLibraryInjectableNameDefault) readResponse(response runtime
 
 	return nil
 }
+
+/*GetWorkflowsLibraryInjectableNameOKBodyBody get workflows library injectable name o k body body
+
+swagger:model GetWorkflowsLibraryInjectableNameOKBodyBody
+*/
+type GetWorkflowsLibraryInjectableNameOKBodyBody interface{}

--- a/client/workflow/get_workflows_responses.go
+++ b/client/workflow/get_workflows_responses.go
@@ -50,7 +50,7 @@ Fetch workflows
 
 */
 type GetWorkflowsOK struct {
-	Payload []interface{}
+	Payload []*models.Graphobject
 }
 
 func (o *GetWorkflowsOK) Error() string {

--- a/client/workflow/workflow_client.go
+++ b/client/workflow/workflow_client.go
@@ -197,9 +197,9 @@ func (a *Client) GetWorkflowsLibrary(params *GetWorkflowsLibraryParams, authInfo
 }
 
 /*
-GetWorkflowsLibraryInjectableName lists all workflows available to run
+GetWorkflowsLibraryInjectableName fetches workflow by injectable name
 
-List all workflows available to run
+Fetch workflow by injectable name
 
 */
 func (a *Client) GetWorkflowsLibraryInjectableName(params *GetWorkflowsLibraryInjectableNameParams, authInfo runtime.ClientAuthInfoWriter) (*GetWorkflowsLibraryInjectableNameOK, error) {

--- a/models/graphobject.go
+++ b/models/graphobject.go
@@ -16,6 +16,10 @@ swagger:model graphobject
 */
 type Graphobject struct {
 
+	/* status
+	 */
+	Status string `json:"_status,omitempty"`
+
 	/* context
 	 */
 	Context interface{} `json:"context,omitempty"`

--- a/swagger-spec/monorail.yml
+++ b/swagger-spec/monorail.yml
@@ -355,7 +355,7 @@ paths:
           schema:
             type: array
             items:
-              type: object
+              $ref: '#/definitions/sku'
         default:
           description: Unexpected error
           schema:
@@ -404,7 +404,7 @@ paths:
           description: |
             return sku
           schema:
-            type: object
+            $ref: '#/definitions/sku'
         404:
           description: |
             There is no sku with identifier.
@@ -434,7 +434,7 @@ paths:
           description: |
             sku to patch
           schema:
-            type: object
+            $ref: '#/definitions/sku'
         404:
           description: |
             Not found, no sku with identifier.
@@ -503,7 +503,7 @@ paths:
           schema:
             type: array
             items:
-              type: object
+              $ref: '#/definitions/node'
         404:
           description: |
             There is no sku with identifier.
@@ -675,9 +675,9 @@ paths:
   /workflows/library/{injectableName}:
     get:
       summary: |
-        List all workflows available to run
+        Fetch workflow by injectable name
       description: |
-        List all workflows available to run
+        Fetch workflow by injectable name
       parameters:
         - name: injectableName
           in: path
@@ -689,11 +689,9 @@ paths:
       responses:
         200:
           description: |
-            List all workflows available to run
+            Fetch workflow by injectable name
           schema:
-            type: array
-            items:
-              type: object
+            type: object
         default:
           description: Unexpected error
           schema:
@@ -793,7 +791,7 @@ paths:
           description: |
             Fetch workflows
           schema:
-            type: object
+            $ref: '#/definitions/graphobject'
         default:
           description: Unexpected error
           schema:
@@ -815,7 +813,7 @@ paths:
           schema:
             type: array
             items:
-              type: object
+              $ref: '#/definitions/graphobject'
         default:
           description: Unexpected error
           schema:
@@ -969,7 +967,7 @@ paths:
           schema:
             type: array
             items:
-              type: object
+              $ref: '#/definitions/graphobject'
         404:
           description: |
             The node with the identifier was not found
@@ -1446,9 +1444,9 @@ paths:
   /nodes/{identifier}:
     get:
       summary: |
-        List of all nodes or if there are none an empty object
+        The node by identifier
       description: |
-        List of all nodes or if there are none an empty object
+        The node by identifier
       parameters:
         - name: identifier
           in: path
@@ -1462,11 +1460,9 @@ paths:
         - get
       responses:
         200:
-          description: array of all
+          description: The node
           schema:
-            type: array
-            items:
-              type: object
+            $ref: '#/definitions/node'
         404:
           description: The node with the identifier was not found.
           schema:
@@ -1529,7 +1525,7 @@ paths:
         200:
           description: patch succeeded
           schema:
-            type: object
+            $ref: '#/definitions/node'
         404:
           description: Not found
           schema:
@@ -1553,7 +1549,7 @@ paths:
           schema:
             type: array
             items:
-              type: object
+              $ref: '#/definitions/node'
         400:
           description: invalidAttributes - 1 attribute is invalid
           schema:
@@ -2023,7 +2019,7 @@ paths:
           schema:
             type: array
             items:
-              type: object
+              $ref: '#/definitions/tag'
         default:
           description: Unexpected error
           schema:
@@ -2116,6 +2112,8 @@ definitions:
   graphobject:
     properties:
       id:
+        type: string
+      _status:
         type: string
       instanceid:
         type: string


### PR DESCRIPTION
Enhance the existing swagger spec by referencing the object definitions
where we can for responses. This enables the generated code to unmarshal
the JSON into the correct model struct, and means that the gorackhd
consumer doesn't have to do it manually.
