### PR TITLE
go-swagger 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 go:
-  - 1.5.1
+  - 1.6.3
+  - 1.7.1
+  - tip
 script:
   - make install

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ cd $GOPATH/src/github.com/codedellemc/gorackhd
 $ make
 ```
 
-The Makefile utilizes [glide](https://github.com/Masterminds/glide) to reference git commit `6b712512cbe1f` of [go-swagger](https://github.com/go-swagger/go-swagger) that has been tested and known to be working. The Makefile will generate a go-swagger directory in `/vendor/github.com/` and then create the client.
+The Makefile utilizes [glide](https://github.com/Masterminds/glide) to reference go-swagger `0.6.0` of [go-swagger](https://github.com/go-swagger/go-swagger). The Makefile will generate a go-swagger directory in `/vendor/github.com/` and then create the client.
 
 ## Environment Variables
 | Name        | Description           |
@@ -44,7 +44,7 @@ import (
     "log"
     "os"
 
-    httptransport "github.com/go-openapi/runtime/client"
+    rc "github.com/go-openapi/runtime/client"
     "github.com/go-openapi/strfmt"
 
     apiclient "github.com/codedellemc/gorackhd/client"
@@ -54,7 +54,7 @@ import (
 func main() {
 
     // create the transport
-    transport := httptransport.New("localhost:9090", "/api/1.1", []string{"http"})
+    transport := rc.New("localhost:9090", "/api/1.1", []string{"http"})
 
     // If not using the Vagrant image, set this environment variable to something other than localhost:9090
     if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -65,7 +65,7 @@ func main() {
     client := apiclient.New(transport, strfmt.Default)
 
     //use any function to do REST operations
-    resp, err := client.Nodes.GetNodes(nil)
+    resp, err := client.Nodes.GetNodes(nil, nil)
     if err != nil {
         log.Fatal(err)
     }
@@ -122,7 +122,9 @@ type Node struct {
         }},
     }
 
-    resp, err := client.Nodes.PostNodes(&nodes.PostNodesParams{Identifiers: c})
+    params := nodes.NewPostNodesParams()
+    params = params.WithIdentifiers(c)
+    resp, err := client.Nodes.PostNodes(params, nil)
     if err != nil {
         log.Fatal(err)
     }
@@ -142,7 +144,9 @@ import (
 
 Lookup the params that are required in a struct:
 ```
-resp, err := client.Skus.GetSkusIdentifier(&nodes.GetNodesIdentifierParams{Identifier: "1234abcd1234abcd1234abcd"})
+    params := nodes.NewGetSkusIdentifierParams()
+    params = params.WithIdentifier("1234abcd1234abcd1234abcd")
+    resp, err := client.Skus.GetSkusIdentifier(params, nil)
     if err != nil {
         log.Fatal(err)
     }
@@ -162,7 +166,9 @@ import (
 
 Lookup the params that are required in a struct:
 ```
-resp, err := client.Nodes.DeleteNodesIdentifier(&nodes.DeleteNodesIdentifierParams{Identifier: "1234abcd1234abcd1234abcd"})
+    params := NewDeleteNodesIdentifierParams()
+    params = params.WithIdentifier("1234abcd1234abcd1234abcd")
+    resp, err := client.Nodes.DeleteNodesIdentifier(params, nil)
     if err != nil {
         log.Fatal(err)
     }

--- a/client/catalog/get_catalogs_identifier_parameters.go
+++ b/client/catalog/get_catalogs_identifier_parameters.go
@@ -4,8 +4,11 @@ package catalog
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetCatalogsIdentifierParams() *GetCatalogsIdentifierParams {
 	var ()
-	return &GetCatalogsIdentifierParams{}
+	return &GetCatalogsIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetCatalogsIdentifierParamsWithTimeout creates a new GetCatalogsIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetCatalogsIdentifierParamsWithTimeout(timeout time.Duration) *GetCatalogsIdentifierParams {
+	var ()
+	return &GetCatalogsIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetCatalogsIdentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetCatalogsIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get catalogs identifier params
-func (o *GetCatalogsIdentifierParams) WithIdentifier(Identifier string) *GetCatalogsIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetCatalogsIdentifierParams) WithIdentifier(identifier string) *GetCatalogsIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetCatalogsIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/catalog/get_catalogs_parameters.go
+++ b/client/catalog/get_catalogs_parameters.go
@@ -4,8 +4,11 @@ package catalog
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetCatalogsParams() *GetCatalogsParams {
 	var ()
-	return &GetCatalogsParams{}
+	return &GetCatalogsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetCatalogsParamsWithTimeout creates a new GetCatalogsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetCatalogsParamsWithTimeout(timeout time.Duration) *GetCatalogsParams {
+	var ()
+	return &GetCatalogsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetCatalogsParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetCatalogsParams struct {
 
 	*/
 	Query *string
+
+	timeout time.Duration
 }
 
 // WithQuery adds the query to the get catalogs params
-func (o *GetCatalogsParams) WithQuery(Query *string) *GetCatalogsParams {
-	o.Query = Query
+func (o *GetCatalogsParams) WithQuery(query *string) *GetCatalogsParams {
+	o.Query = query
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetCatalogsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if o.Query != nil {

--- a/client/catalogs/get_nodes_identifier_catalogs_parameters.go
+++ b/client/catalogs/get_nodes_identifier_catalogs_parameters.go
@@ -4,8 +4,11 @@ package catalogs
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierCatalogsParams() *GetNodesIdentifierCatalogsParams {
 	var ()
-	return &GetNodesIdentifierCatalogsParams{}
+	return &GetNodesIdentifierCatalogsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierCatalogsParamsWithTimeout creates a new GetNodesIdentifierCatalogsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierCatalogsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierCatalogsParams {
+	var ()
+	return &GetNodesIdentifierCatalogsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierCatalogsParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierCatalogsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier catalogs params
-func (o *GetNodesIdentifierCatalogsParams) WithIdentifier(Identifier string) *GetNodesIdentifierCatalogsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierCatalogsParams) WithIdentifier(identifier string) *GetNodesIdentifierCatalogsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierCatalogsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/catalogs/get_nodes_identifier_catalogs_source_parameters.go
+++ b/client/catalogs/get_nodes_identifier_catalogs_source_parameters.go
@@ -4,8 +4,11 @@ package catalogs
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierCatalogsSourceParams() *GetNodesIdentifierCatalogsSourceParams {
 	var ()
-	return &GetNodesIdentifierCatalogsSourceParams{}
+	return &GetNodesIdentifierCatalogsSourceParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierCatalogsSourceParamsWithTimeout creates a new GetNodesIdentifierCatalogsSourceParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierCatalogsSourceParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierCatalogsSourceParams {
+	var ()
+	return &GetNodesIdentifierCatalogsSourceParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierCatalogsSourceParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type GetNodesIdentifierCatalogsSourceParams struct {
 
 	*/
 	Source string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier catalogs source params
-func (o *GetNodesIdentifierCatalogsSourceParams) WithIdentifier(Identifier string) *GetNodesIdentifierCatalogsSourceParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierCatalogsSourceParams) WithIdentifier(identifier string) *GetNodesIdentifierCatalogsSourceParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithSource adds the source to the get nodes identifier catalogs source params
-func (o *GetNodesIdentifierCatalogsSourceParams) WithSource(Source string) *GetNodesIdentifierCatalogsSourceParams {
-	o.Source = Source
+func (o *GetNodesIdentifierCatalogsSourceParams) WithSource(source string) *GetNodesIdentifierCatalogsSourceParams {
+	o.Source = source
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierCatalogsSourceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/config/get_config_parameters.go
+++ b/client/config/get_config_parameters.go
@@ -4,8 +4,11 @@ package config
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetConfigParams() *GetConfigParams {
 
-	return &GetConfigParams{}
+	return &GetConfigParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetConfigParamsWithTimeout creates a new GetConfigParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetConfigParamsWithTimeout(timeout time.Duration) *GetConfigParams {
+
+	return &GetConfigParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetConfigParams contains all the parameters to send to the API endpoint
 for the get config operation typically these are written to a http.Request
 */
 type GetConfigParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/config/patch_config_parameters.go
+++ b/client/config/patch_config_parameters.go
@@ -4,8 +4,11 @@ package config
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchConfigParams() *PatchConfigParams {
 	var ()
-	return &PatchConfigParams{}
+	return &PatchConfigParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchConfigParamsWithTimeout creates a new PatchConfigParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchConfigParamsWithTimeout(timeout time.Duration) *PatchConfigParams {
+	var ()
+	return &PatchConfigParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchConfigParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PatchConfigParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch config params
-func (o *PatchConfigParams) WithBody(Body interface{}) *PatchConfigParams {
-	o.Body = Body
+func (o *PatchConfigParams) WithBody(body interface{}) *PatchConfigParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/delete/delete_dhcp_lease_mac_parameters.go
+++ b/client/delete/delete_dhcp_lease_mac_parameters.go
@@ -4,8 +4,11 @@ package delete
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteDhcpLeaseMacParams() *DeleteDhcpLeaseMacParams {
 	var ()
-	return &DeleteDhcpLeaseMacParams{}
+	return &DeleteDhcpLeaseMacParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteDhcpLeaseMacParamsWithTimeout creates a new DeleteDhcpLeaseMacParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteDhcpLeaseMacParamsWithTimeout(timeout time.Duration) *DeleteDhcpLeaseMacParams {
+	var ()
+	return &DeleteDhcpLeaseMacParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteDhcpLeaseMacParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type DeleteDhcpLeaseMacParams struct {
 
 	*/
 	Mac string
+
+	timeout time.Duration
 }
 
 // WithMac adds the mac to the delete dhcp lease mac params
-func (o *DeleteDhcpLeaseMacParams) WithMac(Mac string) *DeleteDhcpLeaseMacParams {
-	o.Mac = Mac
+func (o *DeleteDhcpLeaseMacParams) WithMac(mac string) *DeleteDhcpLeaseMacParams {
+	o.Mac = mac
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteDhcpLeaseMacParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param mac

--- a/client/delete/delete_files_fileidentifier_parameters.go
+++ b/client/delete/delete_files_fileidentifier_parameters.go
@@ -4,8 +4,11 @@ package delete
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteFilesFileidentifierParams() *DeleteFilesFileidentifierParams {
 	var ()
-	return &DeleteFilesFileidentifierParams{}
+	return &DeleteFilesFileidentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteFilesFileidentifierParamsWithTimeout creates a new DeleteFilesFileidentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteFilesFileidentifierParamsWithTimeout(timeout time.Duration) *DeleteFilesFileidentifierParams {
+	var ()
+	return &DeleteFilesFileidentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteFilesFileidentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type DeleteFilesFileidentifierParams struct {
 
 	*/
 	Fileidentifier string
+
+	timeout time.Duration
 }
 
 // WithFileidentifier adds the fileidentifier to the delete files fileidentifier params
-func (o *DeleteFilesFileidentifierParams) WithFileidentifier(Fileidentifier string) *DeleteFilesFileidentifierParams {
-	o.Fileidentifier = Fileidentifier
+func (o *DeleteFilesFileidentifierParams) WithFileidentifier(fileidentifier string) *DeleteFilesFileidentifierParams {
+	o.Fileidentifier = fileidentifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteFilesFileidentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param fileidentifier

--- a/client/delete/delete_nodes_identifier_parameters.go
+++ b/client/delete/delete_nodes_identifier_parameters.go
@@ -4,8 +4,11 @@ package delete
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierParams() *DeleteNodesIdentifierParams {
 	var ()
-	return &DeleteNodesIdentifierParams{}
+	return &DeleteNodesIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierParamsWithTimeout creates a new DeleteNodesIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierParams {
+	var ()
+	return &DeleteNodesIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier params
-func (o *DeleteNodesIdentifierParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierParams) WithIdentifier(identifier string) *DeleteNodesIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/delete/delete_nodes_identifier_tags_tagname_parameters.go
+++ b/client/delete/delete_nodes_identifier_tags_tagname_parameters.go
@@ -4,8 +4,11 @@ package delete
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierTagsTagnameParams() *DeleteNodesIdentifierTagsTagnameParams {
 	var ()
-	return &DeleteNodesIdentifierTagsTagnameParams{}
+	return &DeleteNodesIdentifierTagsTagnameParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierTagsTagnameParamsWithTimeout creates a new DeleteNodesIdentifierTagsTagnameParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierTagsTagnameParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierTagsTagnameParams {
+	var ()
+	return &DeleteNodesIdentifierTagsTagnameParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierTagsTagnameParams contains all the parameters to send to the API endpoint
@@ -34,23 +50,26 @@ type DeleteNodesIdentifierTagsTagnameParams struct {
 
 	*/
 	Tagname string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier tags tagname params
-func (o *DeleteNodesIdentifierTagsTagnameParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierTagsTagnameParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierTagsTagnameParams) WithIdentifier(identifier string) *DeleteNodesIdentifierTagsTagnameParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithTagname adds the tagname to the delete nodes identifier tags tagname params
-func (o *DeleteNodesIdentifierTagsTagnameParams) WithTagname(Tagname string) *DeleteNodesIdentifierTagsTagnameParams {
-	o.Tagname = Tagname
+func (o *DeleteNodesIdentifierTagsTagnameParams) WithTagname(tagname string) *DeleteNodesIdentifierTagsTagnameParams {
+	o.Tagname = tagname
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierTagsTagnameParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/delete/delete_nodes_identifier_workflows_active_parameters.go
+++ b/client/delete/delete_nodes_identifier_workflows_active_parameters.go
@@ -4,8 +4,11 @@ package delete
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierWorkflowsActiveParams() *DeleteNodesIdentifierWorkflowsActiveParams {
 	var ()
-	return &DeleteNodesIdentifierWorkflowsActiveParams{}
+	return &DeleteNodesIdentifierWorkflowsActiveParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierWorkflowsActiveParamsWithTimeout creates a new DeleteNodesIdentifierWorkflowsActiveParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierWorkflowsActiveParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierWorkflowsActiveParams {
+	var ()
+	return &DeleteNodesIdentifierWorkflowsActiveParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierWorkflowsActiveParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesIdentifierWorkflowsActiveParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier workflows active params
-func (o *DeleteNodesIdentifierWorkflowsActiveParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierWorkflowsActiveParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierWorkflowsActiveParams) WithIdentifier(identifier string) *DeleteNodesIdentifierWorkflowsActiveParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierWorkflowsActiveParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/delete/delete_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/delete/delete_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package delete
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesMacaddressDhcpWhitelistParams() *DeleteNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &DeleteNodesMacaddressDhcpWhitelistParams{}
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new DeleteNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *DeleteNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithMacaddress adds the macaddress to the delete nodes macaddress dhcp whitelist params
-func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param macaddress

--- a/client/delete/delete_pollers_identifier_parameters.go
+++ b/client/delete/delete_pollers_identifier_parameters.go
@@ -4,8 +4,11 @@ package delete
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeletePollersIdentifierParams() *DeletePollersIdentifierParams {
 	var ()
-	return &DeletePollersIdentifierParams{}
+	return &DeletePollersIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeletePollersIdentifierParamsWithTimeout creates a new DeletePollersIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeletePollersIdentifierParamsWithTimeout(timeout time.Duration) *DeletePollersIdentifierParams {
+	var ()
+	return &DeletePollersIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeletePollersIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type DeletePollersIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete pollers identifier params
-func (o *DeletePollersIdentifierParams) WithIdentifier(Identifier string) *DeletePollersIdentifierParams {
-	o.Identifier = Identifier
+func (o *DeletePollersIdentifierParams) WithIdentifier(identifier string) *DeletePollersIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeletePollersIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/dhcp/delete_dhcp_lease_mac_parameters.go
+++ b/client/dhcp/delete_dhcp_lease_mac_parameters.go
@@ -4,8 +4,11 @@ package dhcp
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteDhcpLeaseMacParams() *DeleteDhcpLeaseMacParams {
 	var ()
-	return &DeleteDhcpLeaseMacParams{}
+	return &DeleteDhcpLeaseMacParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteDhcpLeaseMacParamsWithTimeout creates a new DeleteDhcpLeaseMacParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteDhcpLeaseMacParamsWithTimeout(timeout time.Duration) *DeleteDhcpLeaseMacParams {
+	var ()
+	return &DeleteDhcpLeaseMacParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteDhcpLeaseMacParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type DeleteDhcpLeaseMacParams struct {
 
 	*/
 	Mac string
+
+	timeout time.Duration
 }
 
 // WithMac adds the mac to the delete dhcp lease mac params
-func (o *DeleteDhcpLeaseMacParams) WithMac(Mac string) *DeleteDhcpLeaseMacParams {
-	o.Mac = Mac
+func (o *DeleteDhcpLeaseMacParams) WithMac(mac string) *DeleteDhcpLeaseMacParams {
+	o.Mac = mac
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteDhcpLeaseMacParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param mac

--- a/client/dhcp/delete_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/dhcp/delete_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package dhcp
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesMacaddressDhcpWhitelistParams() *DeleteNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &DeleteNodesMacaddressDhcpWhitelistParams{}
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new DeleteNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *DeleteNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithMacaddress adds the macaddress to the delete nodes macaddress dhcp whitelist params
-func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param macaddress

--- a/client/dhcp/get_dhcp_lease_mac_parameters.go
+++ b/client/dhcp/get_dhcp_lease_mac_parameters.go
@@ -4,8 +4,11 @@ package dhcp
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetDhcpLeaseMacParams() *GetDhcpLeaseMacParams {
 	var ()
-	return &GetDhcpLeaseMacParams{}
+	return &GetDhcpLeaseMacParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetDhcpLeaseMacParamsWithTimeout creates a new GetDhcpLeaseMacParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetDhcpLeaseMacParamsWithTimeout(timeout time.Duration) *GetDhcpLeaseMacParams {
+	var ()
+	return &GetDhcpLeaseMacParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetDhcpLeaseMacParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetDhcpLeaseMacParams struct {
 
 	*/
 	Mac string
+
+	timeout time.Duration
 }
 
 // WithMac adds the mac to the get dhcp lease mac params
-func (o *GetDhcpLeaseMacParams) WithMac(Mac string) *GetDhcpLeaseMacParams {
-	o.Mac = Mac
+func (o *GetDhcpLeaseMacParams) WithMac(mac string) *GetDhcpLeaseMacParams {
+	o.Mac = mac
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetDhcpLeaseMacParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param mac

--- a/client/dhcp/get_dhcp_parameters.go
+++ b/client/dhcp/get_dhcp_parameters.go
@@ -4,8 +4,11 @@ package dhcp
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetDhcpParams() *GetDhcpParams {
 
-	return &GetDhcpParams{}
+	return &GetDhcpParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetDhcpParamsWithTimeout creates a new GetDhcpParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetDhcpParamsWithTimeout(timeout time.Duration) *GetDhcpParams {
+
+	return &GetDhcpParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetDhcpParams contains all the parameters to send to the API endpoint
 for the get dhcp operation typically these are written to a http.Request
 */
 type GetDhcpParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetDhcpParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/dhcp/post_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/dhcp/post_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package dhcp
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesMacaddressDhcpWhitelistParams() *PostNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &PostNodesMacaddressDhcpWhitelistParams{}
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new PostNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *PostNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -31,23 +47,26 @@ type PostNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(Body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Body = Body
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Body = body
 	return o
 }
 
 // WithMacaddress adds the macaddress to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/files/delete_files_fileidentifier_parameters.go
+++ b/client/files/delete_files_fileidentifier_parameters.go
@@ -4,8 +4,11 @@ package files
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteFilesFileidentifierParams() *DeleteFilesFileidentifierParams {
 	var ()
-	return &DeleteFilesFileidentifierParams{}
+	return &DeleteFilesFileidentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteFilesFileidentifierParamsWithTimeout creates a new DeleteFilesFileidentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteFilesFileidentifierParamsWithTimeout(timeout time.Duration) *DeleteFilesFileidentifierParams {
+	var ()
+	return &DeleteFilesFileidentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteFilesFileidentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type DeleteFilesFileidentifierParams struct {
 
 	*/
 	Fileidentifier string
+
+	timeout time.Duration
 }
 
 // WithFileidentifier adds the fileidentifier to the delete files fileidentifier params
-func (o *DeleteFilesFileidentifierParams) WithFileidentifier(Fileidentifier string) *DeleteFilesFileidentifierParams {
-	o.Fileidentifier = Fileidentifier
+func (o *DeleteFilesFileidentifierParams) WithFileidentifier(fileidentifier string) *DeleteFilesFileidentifierParams {
+	o.Fileidentifier = fileidentifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteFilesFileidentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param fileidentifier

--- a/client/files/files_client.go
+++ b/client/files/files_client.go
@@ -86,7 +86,7 @@ PutFilesFileidentifier puts file based on filename
 Put file based on filename, returns the uuid of the stored file.
 
 */
-func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierOK, error) {
+func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutFilesFileidentifierParams()
@@ -106,7 +106,7 @@ func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, au
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PutFilesFileidentifierOK), nil
+	return result.(*PutFilesFileidentifierCreated), nil
 }
 
 // SetTransport changes the transport on the client

--- a/client/files/get_files_fileidentifier_parameters.go
+++ b/client/files/get_files_fileidentifier_parameters.go
@@ -4,8 +4,11 @@ package files
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetFilesFileidentifierParams() *GetFilesFileidentifierParams {
 	var ()
-	return &GetFilesFileidentifierParams{}
+	return &GetFilesFileidentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetFilesFileidentifierParamsWithTimeout creates a new GetFilesFileidentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetFilesFileidentifierParamsWithTimeout(timeout time.Duration) *GetFilesFileidentifierParams {
+	var ()
+	return &GetFilesFileidentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetFilesFileidentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetFilesFileidentifierParams struct {
 
 	*/
 	Fileidentifier string
+
+	timeout time.Duration
 }
 
 // WithFileidentifier adds the fileidentifier to the get files fileidentifier params
-func (o *GetFilesFileidentifierParams) WithFileidentifier(Fileidentifier string) *GetFilesFileidentifierParams {
-	o.Fileidentifier = Fileidentifier
+func (o *GetFilesFileidentifierParams) WithFileidentifier(fileidentifier string) *GetFilesFileidentifierParams {
+	o.Fileidentifier = fileidentifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetFilesFileidentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param fileidentifier

--- a/client/files/put_files_fileidentifier_parameters.go
+++ b/client/files/put_files_fileidentifier_parameters.go
@@ -4,8 +4,11 @@ package files
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutFilesFileidentifierParams() *PutFilesFileidentifierParams {
 	var ()
-	return &PutFilesFileidentifierParams{}
+	return &PutFilesFileidentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutFilesFileidentifierParamsWithTimeout creates a new PutFilesFileidentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutFilesFileidentifierParamsWithTimeout(timeout time.Duration) *PutFilesFileidentifierParams {
+	var ()
+	return &PutFilesFileidentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutFilesFileidentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type PutFilesFileidentifierParams struct {
 
 	*/
 	Fileidentifier string
+
+	timeout time.Duration
 }
 
 // WithFileidentifier adds the fileidentifier to the put files fileidentifier params
-func (o *PutFilesFileidentifierParams) WithFileidentifier(Fileidentifier string) *PutFilesFileidentifierParams {
-	o.Fileidentifier = Fileidentifier
+func (o *PutFilesFileidentifierParams) WithFileidentifier(fileidentifier string) *PutFilesFileidentifierParams {
+	o.Fileidentifier = fileidentifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutFilesFileidentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param fileidentifier

--- a/client/get/delete_lookups_id_parameters.go
+++ b/client/get/delete_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteLookupsIDParams() *DeleteLookupsIDParams {
 	var ()
-	return &DeleteLookupsIDParams{}
+	return &DeleteLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteLookupsIDParamsWithTimeout creates a new DeleteLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteLookupsIDParamsWithTimeout(timeout time.Duration) *DeleteLookupsIDParams {
+	var ()
+	return &DeleteLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteLookupsIDParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type DeleteLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithID adds the id to the delete lookups ID params
-func (o *DeleteLookupsIDParams) WithID(ID string) *DeleteLookupsIDParams {
-	o.ID = ID
+func (o *DeleteLookupsIDParams) WithID(id string) *DeleteLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param id

--- a/client/get/get_catalogs_identifier_parameters.go
+++ b/client/get/get_catalogs_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetCatalogsIdentifierParams() *GetCatalogsIdentifierParams {
 	var ()
-	return &GetCatalogsIdentifierParams{}
+	return &GetCatalogsIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetCatalogsIdentifierParamsWithTimeout creates a new GetCatalogsIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetCatalogsIdentifierParamsWithTimeout(timeout time.Duration) *GetCatalogsIdentifierParams {
+	var ()
+	return &GetCatalogsIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetCatalogsIdentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetCatalogsIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get catalogs identifier params
-func (o *GetCatalogsIdentifierParams) WithIdentifier(Identifier string) *GetCatalogsIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetCatalogsIdentifierParams) WithIdentifier(identifier string) *GetCatalogsIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetCatalogsIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_catalogs_parameters.go
+++ b/client/get/get_catalogs_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetCatalogsParams() *GetCatalogsParams {
 	var ()
-	return &GetCatalogsParams{}
+	return &GetCatalogsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetCatalogsParamsWithTimeout creates a new GetCatalogsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetCatalogsParamsWithTimeout(timeout time.Duration) *GetCatalogsParams {
+	var ()
+	return &GetCatalogsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetCatalogsParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetCatalogsParams struct {
 
 	*/
 	Query *string
+
+	timeout time.Duration
 }
 
 // WithQuery adds the query to the get catalogs params
-func (o *GetCatalogsParams) WithQuery(Query *string) *GetCatalogsParams {
-	o.Query = Query
+func (o *GetCatalogsParams) WithQuery(query *string) *GetCatalogsParams {
+	o.Query = query
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetCatalogsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if o.Query != nil {

--- a/client/get/get_config_parameters.go
+++ b/client/get/get_config_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetConfigParams() *GetConfigParams {
 
-	return &GetConfigParams{}
+	return &GetConfigParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetConfigParamsWithTimeout creates a new GetConfigParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetConfigParamsWithTimeout(timeout time.Duration) *GetConfigParams {
+
+	return &GetConfigParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetConfigParams contains all the parameters to send to the API endpoint
 for the get config operation typically these are written to a http.Request
 */
 type GetConfigParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_dhcp_lease_mac_parameters.go
+++ b/client/get/get_dhcp_lease_mac_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetDhcpLeaseMacParams() *GetDhcpLeaseMacParams {
 	var ()
-	return &GetDhcpLeaseMacParams{}
+	return &GetDhcpLeaseMacParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetDhcpLeaseMacParamsWithTimeout creates a new GetDhcpLeaseMacParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetDhcpLeaseMacParamsWithTimeout(timeout time.Duration) *GetDhcpLeaseMacParams {
+	var ()
+	return &GetDhcpLeaseMacParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetDhcpLeaseMacParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetDhcpLeaseMacParams struct {
 
 	*/
 	Mac string
+
+	timeout time.Duration
 }
 
 // WithMac adds the mac to the get dhcp lease mac params
-func (o *GetDhcpLeaseMacParams) WithMac(Mac string) *GetDhcpLeaseMacParams {
-	o.Mac = Mac
+func (o *GetDhcpLeaseMacParams) WithMac(mac string) *GetDhcpLeaseMacParams {
+	o.Mac = mac
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetDhcpLeaseMacParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param mac

--- a/client/get/get_dhcp_parameters.go
+++ b/client/get/get_dhcp_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetDhcpParams() *GetDhcpParams {
 
-	return &GetDhcpParams{}
+	return &GetDhcpParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetDhcpParamsWithTimeout creates a new GetDhcpParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetDhcpParamsWithTimeout(timeout time.Duration) *GetDhcpParams {
+
+	return &GetDhcpParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetDhcpParams contains all the parameters to send to the API endpoint
 for the get dhcp operation typically these are written to a http.Request
 */
 type GetDhcpParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetDhcpParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_files_fileidentifier_parameters.go
+++ b/client/get/get_files_fileidentifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetFilesFileidentifierParams() *GetFilesFileidentifierParams {
 	var ()
-	return &GetFilesFileidentifierParams{}
+	return &GetFilesFileidentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetFilesFileidentifierParamsWithTimeout creates a new GetFilesFileidentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetFilesFileidentifierParamsWithTimeout(timeout time.Duration) *GetFilesFileidentifierParams {
+	var ()
+	return &GetFilesFileidentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetFilesFileidentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetFilesFileidentifierParams struct {
 
 	*/
 	Fileidentifier string
+
+	timeout time.Duration
 }
 
 // WithFileidentifier adds the fileidentifier to the get files fileidentifier params
-func (o *GetFilesFileidentifierParams) WithFileidentifier(Fileidentifier string) *GetFilesFileidentifierParams {
-	o.Fileidentifier = Fileidentifier
+func (o *GetFilesFileidentifierParams) WithFileidentifier(fileidentifier string) *GetFilesFileidentifierParams {
+	o.Fileidentifier = fileidentifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetFilesFileidentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param fileidentifier

--- a/client/get/get_lookups_id_parameters.go
+++ b/client/get/get_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetLookupsIDParams() *GetLookupsIDParams {
 	var ()
-	return &GetLookupsIDParams{}
+	return &GetLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetLookupsIDParamsWithTimeout creates a new GetLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetLookupsIDParamsWithTimeout(timeout time.Duration) *GetLookupsIDParams {
+	var ()
+	return &GetLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetLookupsIDParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithID adds the id to the get lookups ID params
-func (o *GetLookupsIDParams) WithID(ID string) *GetLookupsIDParams {
-	o.ID = ID
+func (o *GetLookupsIDParams) WithID(id string) *GetLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param id

--- a/client/get/get_lookups_parameters.go
+++ b/client/get/get_lookups_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetLookupsParams() *GetLookupsParams {
 	var ()
-	return &GetLookupsParams{}
+	return &GetLookupsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetLookupsParamsWithTimeout creates a new GetLookupsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetLookupsParamsWithTimeout(timeout time.Duration) *GetLookupsParams {
+	var ()
+	return &GetLookupsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetLookupsParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetLookupsParams struct {
 
 	*/
 	Q *string
+
+	timeout time.Duration
 }
 
 // WithQ adds the q to the get lookups params
-func (o *GetLookupsParams) WithQ(Q *string) *GetLookupsParams {
-	o.Q = Q
+func (o *GetLookupsParams) WithQ(q *string) *GetLookupsParams {
+	o.Q = q
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetLookupsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if o.Q != nil {

--- a/client/get/get_nodes_identifier_catalogs_parameters.go
+++ b/client/get/get_nodes_identifier_catalogs_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierCatalogsParams() *GetNodesIdentifierCatalogsParams {
 	var ()
-	return &GetNodesIdentifierCatalogsParams{}
+	return &GetNodesIdentifierCatalogsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierCatalogsParamsWithTimeout creates a new GetNodesIdentifierCatalogsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierCatalogsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierCatalogsParams {
+	var ()
+	return &GetNodesIdentifierCatalogsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierCatalogsParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierCatalogsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier catalogs params
-func (o *GetNodesIdentifierCatalogsParams) WithIdentifier(Identifier string) *GetNodesIdentifierCatalogsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierCatalogsParams) WithIdentifier(identifier string) *GetNodesIdentifierCatalogsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierCatalogsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_catalogs_source_parameters.go
+++ b/client/get/get_nodes_identifier_catalogs_source_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierCatalogsSourceParams() *GetNodesIdentifierCatalogsSourceParams {
 	var ()
-	return &GetNodesIdentifierCatalogsSourceParams{}
+	return &GetNodesIdentifierCatalogsSourceParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierCatalogsSourceParamsWithTimeout creates a new GetNodesIdentifierCatalogsSourceParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierCatalogsSourceParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierCatalogsSourceParams {
+	var ()
+	return &GetNodesIdentifierCatalogsSourceParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierCatalogsSourceParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type GetNodesIdentifierCatalogsSourceParams struct {
 
 	*/
 	Source string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier catalogs source params
-func (o *GetNodesIdentifierCatalogsSourceParams) WithIdentifier(Identifier string) *GetNodesIdentifierCatalogsSourceParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierCatalogsSourceParams) WithIdentifier(identifier string) *GetNodesIdentifierCatalogsSourceParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithSource adds the source to the get nodes identifier catalogs source params
-func (o *GetNodesIdentifierCatalogsSourceParams) WithSource(Source string) *GetNodesIdentifierCatalogsSourceParams {
-	o.Source = Source
+func (o *GetNodesIdentifierCatalogsSourceParams) WithSource(source string) *GetNodesIdentifierCatalogsSourceParams {
+	o.Source = source
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierCatalogsSourceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_obm_identify_parameters.go
+++ b/client/get/get_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierObmIdentifyParams() *GetNodesIdentifierObmIdentifyParams {
 	var ()
-	return &GetNodesIdentifierObmIdentifyParams{}
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierObmIdentifyParamsWithTimeout creates a new GetNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierObmIdentifyParams {
+	var ()
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier obm identify params
-func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *GetNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *GetNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_obm_parameters.go
+++ b/client/get/get_nodes_identifier_obm_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierObmParams() *GetNodesIdentifierObmParams {
 	var ()
-	return &GetNodesIdentifierObmParams{}
+	return &GetNodesIdentifierObmParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierObmParamsWithTimeout creates a new GetNodesIdentifierObmParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierObmParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierObmParams {
+	var ()
+	return &GetNodesIdentifierObmParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierObmParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierObmParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier obm params
-func (o *GetNodesIdentifierObmParams) WithIdentifier(Identifier string) *GetNodesIdentifierObmParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierObmParams) WithIdentifier(identifier string) *GetNodesIdentifierObmParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierObmParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_parameters.go
+++ b/client/get/get_nodes_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierParams() *GetNodesIdentifierParams {
 	var ()
-	return &GetNodesIdentifierParams{}
+	return &GetNodesIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierParamsWithTimeout creates a new GetNodesIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierParams {
+	var ()
+	return &GetNodesIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier params
-func (o *GetNodesIdentifierParams) WithIdentifier(Identifier string) *GetNodesIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierParams) WithIdentifier(identifier string) *GetNodesIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_pollers_parameters.go
+++ b/client/get/get_nodes_identifier_pollers_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierPollersParams() *GetNodesIdentifierPollersParams {
 	var ()
-	return &GetNodesIdentifierPollersParams{}
+	return &GetNodesIdentifierPollersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierPollersParamsWithTimeout creates a new GetNodesIdentifierPollersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierPollersParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierPollersParams {
+	var ()
+	return &GetNodesIdentifierPollersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierPollersParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierPollersParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier pollers params
-func (o *GetNodesIdentifierPollersParams) WithIdentifier(Identifier string) *GetNodesIdentifierPollersParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierPollersParams) WithIdentifier(identifier string) *GetNodesIdentifierPollersParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierPollersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_tags_parameters.go
+++ b/client/get/get_nodes_identifier_tags_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierTagsParams() *GetNodesIdentifierTagsParams {
 	var ()
-	return &GetNodesIdentifierTagsParams{}
+	return &GetNodesIdentifierTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierTagsParamsWithTimeout creates a new GetNodesIdentifierTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierTagsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierTagsParams {
+	var ()
+	return &GetNodesIdentifierTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierTagsParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetNodesIdentifierTagsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier tags params
-func (o *GetNodesIdentifierTagsParams) WithIdentifier(Identifier string) *GetNodesIdentifierTagsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierTagsParams) WithIdentifier(identifier string) *GetNodesIdentifierTagsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_workflows_active_parameters.go
+++ b/client/get/get_nodes_identifier_workflows_active_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierWorkflowsActiveParams() *GetNodesIdentifierWorkflowsActiveParams {
 	var ()
-	return &GetNodesIdentifierWorkflowsActiveParams{}
+	return &GetNodesIdentifierWorkflowsActiveParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierWorkflowsActiveParamsWithTimeout creates a new GetNodesIdentifierWorkflowsActiveParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierWorkflowsActiveParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierWorkflowsActiveParams {
+	var ()
+	return &GetNodesIdentifierWorkflowsActiveParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierWorkflowsActiveParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierWorkflowsActiveParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier workflows active params
-func (o *GetNodesIdentifierWorkflowsActiveParams) WithIdentifier(Identifier string) *GetNodesIdentifierWorkflowsActiveParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierWorkflowsActiveParams) WithIdentifier(identifier string) *GetNodesIdentifierWorkflowsActiveParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierWorkflowsActiveParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_identifier_workflows_parameters.go
+++ b/client/get/get_nodes_identifier_workflows_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierWorkflowsParams() *GetNodesIdentifierWorkflowsParams {
 	var ()
-	return &GetNodesIdentifierWorkflowsParams{}
+	return &GetNodesIdentifierWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierWorkflowsParamsWithTimeout creates a new GetNodesIdentifierWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierWorkflowsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierWorkflowsParams {
+	var ()
+	return &GetNodesIdentifierWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierWorkflowsParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierWorkflowsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier workflows params
-func (o *GetNodesIdentifierWorkflowsParams) WithIdentifier(Identifier string) *GetNodesIdentifierWorkflowsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierWorkflowsParams) WithIdentifier(identifier string) *GetNodesIdentifierWorkflowsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_nodes_parameters.go
+++ b/client/get/get_nodes_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetNodesParams() *GetNodesParams {
 
-	return &GetNodesParams{}
+	return &GetNodesParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesParamsWithTimeout creates a new GetNodesParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesParamsWithTimeout(timeout time.Duration) *GetNodesParams {
+
+	return &GetNodesParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesParams contains all the parameters to send to the API endpoint
 for the get nodes operation typically these are written to a http.Request
 */
 type GetNodesParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_obms_library_identifier_parameters.go
+++ b/client/get/get_obms_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetObmsLibraryIdentifierParams() *GetObmsLibraryIdentifierParams {
 	var ()
-	return &GetObmsLibraryIdentifierParams{}
+	return &GetObmsLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetObmsLibraryIdentifierParamsWithTimeout creates a new GetObmsLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetObmsLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetObmsLibraryIdentifierParams {
+	var ()
+	return &GetObmsLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetObmsLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetObmsLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get obms library identifier params
-func (o *GetObmsLibraryIdentifierParams) WithIdentifier(Identifier string) *GetObmsLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetObmsLibraryIdentifierParams) WithIdentifier(identifier string) *GetObmsLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetObmsLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_obms_library_parameters.go
+++ b/client/get/get_obms_library_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetObmsLibraryParams() *GetObmsLibraryParams {
 
-	return &GetObmsLibraryParams{}
+	return &GetObmsLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetObmsLibraryParamsWithTimeout creates a new GetObmsLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetObmsLibraryParamsWithTimeout(timeout time.Duration) *GetObmsLibraryParams {
+
+	return &GetObmsLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetObmsLibraryParams contains all the parameters to send to the API endpoint
 for the get obms library operation typically these are written to a http.Request
 */
 type GetObmsLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetObmsLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_pollers_identifier_data_parameters.go
+++ b/client/get/get_pollers_identifier_data_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetPollersIdentifierDataParams() *GetPollersIdentifierDataParams {
 	var ()
-	return &GetPollersIdentifierDataParams{}
+	return &GetPollersIdentifierDataParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersIdentifierDataParamsWithTimeout creates a new GetPollersIdentifierDataParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersIdentifierDataParamsWithTimeout(timeout time.Duration) *GetPollersIdentifierDataParams {
+	var ()
+	return &GetPollersIdentifierDataParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersIdentifierDataParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetPollersIdentifierDataParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get pollers identifier data params
-func (o *GetPollersIdentifierDataParams) WithIdentifier(Identifier string) *GetPollersIdentifierDataParams {
-	o.Identifier = Identifier
+func (o *GetPollersIdentifierDataParams) WithIdentifier(identifier string) *GetPollersIdentifierDataParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersIdentifierDataParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_pollers_identifier_parameters.go
+++ b/client/get/get_pollers_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetPollersIdentifierParams() *GetPollersIdentifierParams {
 	var ()
-	return &GetPollersIdentifierParams{}
+	return &GetPollersIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersIdentifierParamsWithTimeout creates a new GetPollersIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersIdentifierParamsWithTimeout(timeout time.Duration) *GetPollersIdentifierParams {
+	var ()
+	return &GetPollersIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetPollersIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get pollers identifier params
-func (o *GetPollersIdentifierParams) WithIdentifier(Identifier string) *GetPollersIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetPollersIdentifierParams) WithIdentifier(identifier string) *GetPollersIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_pollers_library_identifier_parameters.go
+++ b/client/get/get_pollers_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetPollersLibraryIdentifierParams() *GetPollersLibraryIdentifierParams {
 	var ()
-	return &GetPollersLibraryIdentifierParams{}
+	return &GetPollersLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersLibraryIdentifierParamsWithTimeout creates a new GetPollersLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetPollersLibraryIdentifierParams {
+	var ()
+	return &GetPollersLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetPollersLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get pollers library identifier params
-func (o *GetPollersLibraryIdentifierParams) WithIdentifier(Identifier string) *GetPollersLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetPollersLibraryIdentifierParams) WithIdentifier(identifier string) *GetPollersLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_pollers_library_parameters.go
+++ b/client/get/get_pollers_library_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetPollersLibraryParams() *GetPollersLibraryParams {
 
-	return &GetPollersLibraryParams{}
+	return &GetPollersLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersLibraryParamsWithTimeout creates a new GetPollersLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersLibraryParamsWithTimeout(timeout time.Duration) *GetPollersLibraryParams {
+
+	return &GetPollersLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersLibraryParams contains all the parameters to send to the API endpoint
 for the get pollers library operation typically these are written to a http.Request
 */
 type GetPollersLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_pollers_parameters.go
+++ b/client/get/get_pollers_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetPollersParams() *GetPollersParams {
 
-	return &GetPollersParams{}
+	return &GetPollersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersParamsWithTimeout creates a new GetPollersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersParamsWithTimeout(timeout time.Duration) *GetPollersParams {
+
+	return &GetPollersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersParams contains all the parameters to send to the API endpoint
 for the get pollers operation typically these are written to a http.Request
 */
 type GetPollersParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_profiles_library_identifier_parameters.go
+++ b/client/get/get_profiles_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetProfilesLibraryIdentifierParams() *GetProfilesLibraryIdentifierParams {
 	var ()
-	return &GetProfilesLibraryIdentifierParams{}
+	return &GetProfilesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetProfilesLibraryIdentifierParamsWithTimeout creates a new GetProfilesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetProfilesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetProfilesLibraryIdentifierParams {
+	var ()
+	return &GetProfilesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetProfilesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetProfilesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get profiles library identifier params
-func (o *GetProfilesLibraryIdentifierParams) WithIdentifier(Identifier string) *GetProfilesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetProfilesLibraryIdentifierParams) WithIdentifier(identifier string) *GetProfilesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetProfilesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_profiles_library_parameters.go
+++ b/client/get/get_profiles_library_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetProfilesLibraryParams() *GetProfilesLibraryParams {
 
-	return &GetProfilesLibraryParams{}
+	return &GetProfilesLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetProfilesLibraryParamsWithTimeout creates a new GetProfilesLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetProfilesLibraryParamsWithTimeout(timeout time.Duration) *GetProfilesLibraryParams {
+
+	return &GetProfilesLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetProfilesLibraryParams contains all the parameters to send to the API endpoint
 for the get profiles library operation typically these are written to a http.Request
 */
 type GetProfilesLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetProfilesLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_skus_identifier_nodes_parameters.go
+++ b/client/get/get_skus_identifier_nodes_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetSkusIdentifierNodesParams() *GetSkusIdentifierNodesParams {
 	var ()
-	return &GetSkusIdentifierNodesParams{}
+	return &GetSkusIdentifierNodesParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetSkusIdentifierNodesParamsWithTimeout creates a new GetSkusIdentifierNodesParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetSkusIdentifierNodesParamsWithTimeout(timeout time.Duration) *GetSkusIdentifierNodesParams {
+	var ()
+	return &GetSkusIdentifierNodesParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetSkusIdentifierNodesParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetSkusIdentifierNodesParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get skus identifier nodes params
-func (o *GetSkusIdentifierNodesParams) WithIdentifier(Identifier string) *GetSkusIdentifierNodesParams {
-	o.Identifier = Identifier
+func (o *GetSkusIdentifierNodesParams) WithIdentifier(identifier string) *GetSkusIdentifierNodesParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetSkusIdentifierNodesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_skus_identifier_parameters.go
+++ b/client/get/get_skus_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetSkusIdentifierParams() *GetSkusIdentifierParams {
 	var ()
-	return &GetSkusIdentifierParams{}
+	return &GetSkusIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetSkusIdentifierParamsWithTimeout creates a new GetSkusIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetSkusIdentifierParamsWithTimeout(timeout time.Duration) *GetSkusIdentifierParams {
+	var ()
+	return &GetSkusIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetSkusIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetSkusIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get skus identifier params
-func (o *GetSkusIdentifierParams) WithIdentifier(Identifier string) *GetSkusIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetSkusIdentifierParams) WithIdentifier(identifier string) *GetSkusIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetSkusIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_skus_parameters.go
+++ b/client/get/get_skus_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetSkusParams() *GetSkusParams {
 
-	return &GetSkusParams{}
+	return &GetSkusParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetSkusParamsWithTimeout creates a new GetSkusParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetSkusParamsWithTimeout(timeout time.Duration) *GetSkusParams {
+
+	return &GetSkusParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetSkusParams contains all the parameters to send to the API endpoint
 for the get skus operation typically these are written to a http.Request
 */
 type GetSkusParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetSkusParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_tags_parameters.go
+++ b/client/get/get_tags_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetTagsParams() *GetTagsParams {
 
-	return &GetTagsParams{}
+	return &GetTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetTagsParamsWithTimeout creates a new GetTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetTagsParamsWithTimeout(timeout time.Duration) *GetTagsParams {
+
+	return &GetTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetTagsParams contains all the parameters to send to the API endpoint
 for the get tags operation typically these are written to a http.Request
 */
 type GetTagsParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_templates_library_identifier_parameters.go
+++ b/client/get/get_templates_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetTemplatesLibraryIdentifierParams() *GetTemplatesLibraryIdentifierParams {
 	var ()
-	return &GetTemplatesLibraryIdentifierParams{}
+	return &GetTemplatesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetTemplatesLibraryIdentifierParamsWithTimeout creates a new GetTemplatesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetTemplatesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetTemplatesLibraryIdentifierParams {
+	var ()
+	return &GetTemplatesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetTemplatesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetTemplatesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get templates library identifier params
-func (o *GetTemplatesLibraryIdentifierParams) WithIdentifier(Identifier string) *GetTemplatesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetTemplatesLibraryIdentifierParams) WithIdentifier(identifier string) *GetTemplatesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetTemplatesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/get/get_templates_library_parameters.go
+++ b/client/get/get_templates_library_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetTemplatesLibraryParams() *GetTemplatesLibraryParams {
 
-	return &GetTemplatesLibraryParams{}
+	return &GetTemplatesLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetTemplatesLibraryParamsWithTimeout creates a new GetTemplatesLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetTemplatesLibraryParamsWithTimeout(timeout time.Duration) *GetTemplatesLibraryParams {
+
+	return &GetTemplatesLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetTemplatesLibraryParams contains all the parameters to send to the API endpoint
 for the get templates library operation typically these are written to a http.Request
 */
 type GetTemplatesLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetTemplatesLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_versions_parameters.go
+++ b/client/get/get_versions_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetVersionsParams() *GetVersionsParams {
 
-	return &GetVersionsParams{}
+	return &GetVersionsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetVersionsParamsWithTimeout creates a new GetVersionsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetVersionsParamsWithTimeout(timeout time.Duration) *GetVersionsParams {
+
+	return &GetVersionsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetVersionsParams contains all the parameters to send to the API endpoint
 for the get versions operation typically these are written to a http.Request
 */
 type GetVersionsParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetVersionsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_workflows_instance_id_parameters.go
+++ b/client/get/get_workflows_instance_id_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsInstanceIDParams() *GetWorkflowsInstanceIDParams {
 	var ()
-	return &GetWorkflowsInstanceIDParams{}
+	return &GetWorkflowsInstanceIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsInstanceIDParamsWithTimeout creates a new GetWorkflowsInstanceIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsInstanceIDParamsWithTimeout(timeout time.Duration) *GetWorkflowsInstanceIDParams {
+	var ()
+	return &GetWorkflowsInstanceIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsInstanceIDParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type GetWorkflowsInstanceIDParams struct {
 
 	/*InstanceID*/
 	InstanceID string
+
+	timeout time.Duration
 }
 
-// WithInstanceID adds the instanceId to the get workflows instance ID params
-func (o *GetWorkflowsInstanceIDParams) WithInstanceID(InstanceID string) *GetWorkflowsInstanceIDParams {
-	o.InstanceID = InstanceID
+// WithInstanceID adds the instanceID to the get workflows instance ID params
+func (o *GetWorkflowsInstanceIDParams) WithInstanceID(instanceID string) *GetWorkflowsInstanceIDParams {
+	o.InstanceID = instanceID
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsInstanceIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param instanceId

--- a/client/get/get_workflows_library_injectable_name_parameters.go
+++ b/client/get/get_workflows_library_injectable_name_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsLibraryInjectableNameParams() *GetWorkflowsLibraryInjectableNameParams {
 	var ()
-	return &GetWorkflowsLibraryInjectableNameParams{}
+	return &GetWorkflowsLibraryInjectableNameParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsLibraryInjectableNameParamsWithTimeout creates a new GetWorkflowsLibraryInjectableNameParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsLibraryInjectableNameParamsWithTimeout(timeout time.Duration) *GetWorkflowsLibraryInjectableNameParams {
+	var ()
+	return &GetWorkflowsLibraryInjectableNameParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsLibraryInjectableNameParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type GetWorkflowsLibraryInjectableNameParams struct {
 
 	/*InjectableName*/
 	InjectableName string
+
+	timeout time.Duration
 }
 
 // WithInjectableName adds the injectableName to the get workflows library injectable name params
-func (o *GetWorkflowsLibraryInjectableNameParams) WithInjectableName(InjectableName string) *GetWorkflowsLibraryInjectableNameParams {
-	o.InjectableName = InjectableName
+func (o *GetWorkflowsLibraryInjectableNameParams) WithInjectableName(injectableName string) *GetWorkflowsLibraryInjectableNameParams {
+	o.InjectableName = injectableName
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsLibraryInjectableNameParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param injectableName

--- a/client/get/get_workflows_library_parameters.go
+++ b/client/get/get_workflows_library_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsLibraryParams() *GetWorkflowsLibraryParams {
 
-	return &GetWorkflowsLibraryParams{}
+	return &GetWorkflowsLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsLibraryParamsWithTimeout creates a new GetWorkflowsLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsLibraryParamsWithTimeout(timeout time.Duration) *GetWorkflowsLibraryParams {
+
+	return &GetWorkflowsLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsLibraryParams contains all the parameters to send to the API endpoint
 for the get workflows library operation typically these are written to a http.Request
 */
 type GetWorkflowsLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_workflows_parameters.go
+++ b/client/get/get_workflows_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsParams() *GetWorkflowsParams {
 
-	return &GetWorkflowsParams{}
+	return &GetWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsParamsWithTimeout creates a new GetWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsParamsWithTimeout(timeout time.Duration) *GetWorkflowsParams {
+
+	return &GetWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsParams contains all the parameters to send to the API endpoint
 for the get workflows operation typically these are written to a http.Request
 */
 type GetWorkflowsParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_workflows_tasks_library_parameters.go
+++ b/client/get/get_workflows_tasks_library_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsTasksLibraryParams() *GetWorkflowsTasksLibraryParams {
 
-	return &GetWorkflowsTasksLibraryParams{}
+	return &GetWorkflowsTasksLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsTasksLibraryParamsWithTimeout creates a new GetWorkflowsTasksLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsTasksLibraryParamsWithTimeout(timeout time.Duration) *GetWorkflowsTasksLibraryParams {
+
+	return &GetWorkflowsTasksLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsTasksLibraryParams contains all the parameters to send to the API endpoint
 for the get workflows tasks library operation typically these are written to a http.Request
 */
 type GetWorkflowsTasksLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsTasksLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/get_workflows_tasks_parameters.go
+++ b/client/get/get_workflows_tasks_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsTasksParams() *GetWorkflowsTasksParams {
 
-	return &GetWorkflowsTasksParams{}
+	return &GetWorkflowsTasksParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsTasksParamsWithTimeout creates a new GetWorkflowsTasksParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsTasksParamsWithTimeout(timeout time.Duration) *GetWorkflowsTasksParams {
+
+	return &GetWorkflowsTasksParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsTasksParams contains all the parameters to send to the API endpoint
 for the get workflows tasks operation typically these are written to a http.Request
 */
 type GetWorkflowsTasksParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsTasksParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/get/patch_lookups_id_parameters.go
+++ b/client/get/patch_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchLookupsIDParams() *PatchLookupsIDParams {
 	var ()
-	return &PatchLookupsIDParams{}
+	return &PatchLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchLookupsIDParamsWithTimeout creates a new PatchLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchLookupsIDParamsWithTimeout(timeout time.Duration) *PatchLookupsIDParams {
+	var ()
+	return &PatchLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchLookupsIDParams contains all the parameters to send to the API endpoint
@@ -33,23 +49,26 @@ type PatchLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch lookups ID params
-func (o *PatchLookupsIDParams) WithBody(Body interface{}) *PatchLookupsIDParams {
-	o.Body = Body
+func (o *PatchLookupsIDParams) WithBody(body interface{}) *PatchLookupsIDParams {
+	o.Body = body
 	return o
 }
 
 // WithID adds the id to the patch lookups ID params
-func (o *PatchLookupsIDParams) WithID(ID string) *PatchLookupsIDParams {
-	o.ID = ID
+func (o *PatchLookupsIDParams) WithID(id string) *PatchLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/get/post_pollers_parameters.go
+++ b/client/get/post_pollers_parameters.go
@@ -4,8 +4,11 @@ package get
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewPostPollersParams() *PostPollersParams {
 
-	return &PostPollersParams{}
+	return &PostPollersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostPollersParamsWithTimeout creates a new PostPollersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostPollersParamsWithTimeout(timeout time.Duration) *PostPollersParams {
+
+	return &PostPollersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostPollersParams contains all the parameters to send to the API endpoint
 for the post pollers operation typically these are written to a http.Request
 */
 type PostPollersParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostPollersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/identify/get_nodes_identifier_obm_identify_parameters.go
+++ b/client/identify/get_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package identify
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierObmIdentifyParams() *GetNodesIdentifierObmIdentifyParams {
 	var ()
-	return &GetNodesIdentifierObmIdentifyParams{}
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierObmIdentifyParamsWithTimeout creates a new GetNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierObmIdentifyParams {
+	var ()
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier obm identify params
-func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *GetNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *GetNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/identify/post_nodes_identifier_obm_identify_parameters.go
+++ b/client/identify/post_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package identify
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierObmIdentifyParams() *PostNodesIdentifierObmIdentifyParams {
 	var ()
-	return &PostNodesIdentifierObmIdentifyParams{}
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierObmIdentifyParamsWithTimeout creates a new PostNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierObmIdentifyParams {
+	var ()
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PostNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithBody(Body *bool) *PostNodesIdentifierObmIdentifyParams {
-	o.Body = Body
+func (o *PostNodesIdentifierObmIdentifyParams) WithBody(body *bool) *PostNodesIdentifierObmIdentifyParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *PostNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *PostNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/lookups/delete_lookups_id_parameters.go
+++ b/client/lookups/delete_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package lookups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteLookupsIDParams() *DeleteLookupsIDParams {
 	var ()
-	return &DeleteLookupsIDParams{}
+	return &DeleteLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteLookupsIDParamsWithTimeout creates a new DeleteLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteLookupsIDParamsWithTimeout(timeout time.Duration) *DeleteLookupsIDParams {
+	var ()
+	return &DeleteLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteLookupsIDParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type DeleteLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithID adds the id to the delete lookups ID params
-func (o *DeleteLookupsIDParams) WithID(ID string) *DeleteLookupsIDParams {
-	o.ID = ID
+func (o *DeleteLookupsIDParams) WithID(id string) *DeleteLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param id

--- a/client/lookups/get_lookups_id_parameters.go
+++ b/client/lookups/get_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package lookups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetLookupsIDParams() *GetLookupsIDParams {
 	var ()
-	return &GetLookupsIDParams{}
+	return &GetLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetLookupsIDParamsWithTimeout creates a new GetLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetLookupsIDParamsWithTimeout(timeout time.Duration) *GetLookupsIDParams {
+	var ()
+	return &GetLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetLookupsIDParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithID adds the id to the get lookups ID params
-func (o *GetLookupsIDParams) WithID(ID string) *GetLookupsIDParams {
-	o.ID = ID
+func (o *GetLookupsIDParams) WithID(id string) *GetLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param id

--- a/client/lookups/get_lookups_parameters.go
+++ b/client/lookups/get_lookups_parameters.go
@@ -4,8 +4,11 @@ package lookups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetLookupsParams() *GetLookupsParams {
 	var ()
-	return &GetLookupsParams{}
+	return &GetLookupsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetLookupsParamsWithTimeout creates a new GetLookupsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetLookupsParamsWithTimeout(timeout time.Duration) *GetLookupsParams {
+	var ()
+	return &GetLookupsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetLookupsParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type GetLookupsParams struct {
 
 	*/
 	Q *string
+
+	timeout time.Duration
 }
 
 // WithQ adds the q to the get lookups params
-func (o *GetLookupsParams) WithQ(Q *string) *GetLookupsParams {
-	o.Q = Q
+func (o *GetLookupsParams) WithQ(q *string) *GetLookupsParams {
+	o.Q = q
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetLookupsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if o.Q != nil {

--- a/client/lookups/patch_lookups_id_parameters.go
+++ b/client/lookups/patch_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package lookups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchLookupsIDParams() *PatchLookupsIDParams {
 	var ()
-	return &PatchLookupsIDParams{}
+	return &PatchLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchLookupsIDParamsWithTimeout creates a new PatchLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchLookupsIDParamsWithTimeout(timeout time.Duration) *PatchLookupsIDParams {
+	var ()
+	return &PatchLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchLookupsIDParams contains all the parameters to send to the API endpoint
@@ -33,23 +49,26 @@ type PatchLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch lookups ID params
-func (o *PatchLookupsIDParams) WithBody(Body interface{}) *PatchLookupsIDParams {
-	o.Body = Body
+func (o *PatchLookupsIDParams) WithBody(body interface{}) *PatchLookupsIDParams {
+	o.Body = body
 	return o
 }
 
 // WithID adds the id to the patch lookups ID params
-func (o *PatchLookupsIDParams) WithID(ID string) *PatchLookupsIDParams {
-	o.ID = ID
+func (o *PatchLookupsIDParams) WithID(id string) *PatchLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/lookups/post_lookups_id_parameters.go
+++ b/client/lookups/post_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package lookups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostLookupsIDParams() *PostLookupsIDParams {
 	var ()
-	return &PostLookupsIDParams{}
+	return &PostLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostLookupsIDParamsWithTimeout creates a new PostLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostLookupsIDParamsWithTimeout(timeout time.Duration) *PostLookupsIDParams {
+	var ()
+	return &PostLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostLookupsIDParams contains all the parameters to send to the API endpoint
@@ -32,23 +48,26 @@ type PostLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithContent adds the content to the post lookups ID params
-func (o *PostLookupsIDParams) WithContent(Content interface{}) *PostLookupsIDParams {
-	o.Content = Content
+func (o *PostLookupsIDParams) WithContent(content interface{}) *PostLookupsIDParams {
+	o.Content = content
 	return o
 }
 
 // WithID adds the id to the post lookups ID params
-func (o *PostLookupsIDParams) WithID(ID string) *PostLookupsIDParams {
-	o.ID = ID
+func (o *PostLookupsIDParams) WithID(id string) *PostLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Content); err != nil {

--- a/client/lookups/post_lookups_parameters.go
+++ b/client/lookups/post_lookups_parameters.go
@@ -4,8 +4,11 @@ package lookups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostLookupsParams() *PostLookupsParams {
 	var ()
-	return &PostLookupsParams{}
+	return &PostLookupsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostLookupsParamsWithTimeout creates a new PostLookupsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostLookupsParamsWithTimeout(timeout time.Duration) *PostLookupsParams {
+	var ()
+	return &PostLookupsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostLookupsParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type PostLookupsParams struct {
 
 	*/
 	Content interface{}
+
+	timeout time.Duration
 }
 
 // WithContent adds the content to the post lookups params
-func (o *PostLookupsParams) WithContent(Content interface{}) *PostLookupsParams {
-	o.Content = Content
+func (o *PostLookupsParams) WithContent(content interface{}) *PostLookupsParams {
+	o.Content = content
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostLookupsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Content); err != nil {

--- a/client/monorail_client.go
+++ b/client/monorail_client.go
@@ -43,7 +43,7 @@ func NewHTTPClient(formats strfmt.Registry) *Monorail {
 	if formats == nil {
 		formats = strfmt.Default
 	}
-	transport := httptransport.New("localhost", "/api/1.1", []string{"https", "http"})
+	transport := httptransport.New("localhost", "/api/1.1", []string{"http", "https"})
 	return New(transport, formats)
 }
 

--- a/client/nodes/delete_nodes_identifier_parameters.go
+++ b/client/nodes/delete_nodes_identifier_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierParams() *DeleteNodesIdentifierParams {
 	var ()
-	return &DeleteNodesIdentifierParams{}
+	return &DeleteNodesIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierParamsWithTimeout creates a new DeleteNodesIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierParams {
+	var ()
+	return &DeleteNodesIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier params
-func (o *DeleteNodesIdentifierParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierParams) WithIdentifier(identifier string) *DeleteNodesIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/delete_nodes_identifier_tags_tagname_parameters.go
+++ b/client/nodes/delete_nodes_identifier_tags_tagname_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierTagsTagnameParams() *DeleteNodesIdentifierTagsTagnameParams {
 	var ()
-	return &DeleteNodesIdentifierTagsTagnameParams{}
+	return &DeleteNodesIdentifierTagsTagnameParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierTagsTagnameParamsWithTimeout creates a new DeleteNodesIdentifierTagsTagnameParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierTagsTagnameParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierTagsTagnameParams {
+	var ()
+	return &DeleteNodesIdentifierTagsTagnameParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierTagsTagnameParams contains all the parameters to send to the API endpoint
@@ -34,23 +50,26 @@ type DeleteNodesIdentifierTagsTagnameParams struct {
 
 	*/
 	Tagname string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier tags tagname params
-func (o *DeleteNodesIdentifierTagsTagnameParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierTagsTagnameParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierTagsTagnameParams) WithIdentifier(identifier string) *DeleteNodesIdentifierTagsTagnameParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithTagname adds the tagname to the delete nodes identifier tags tagname params
-func (o *DeleteNodesIdentifierTagsTagnameParams) WithTagname(Tagname string) *DeleteNodesIdentifierTagsTagnameParams {
-	o.Tagname = Tagname
+func (o *DeleteNodesIdentifierTagsTagnameParams) WithTagname(tagname string) *DeleteNodesIdentifierTagsTagnameParams {
+	o.Tagname = tagname
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierTagsTagnameParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/delete_nodes_identifier_workflows_active_parameters.go
+++ b/client/nodes/delete_nodes_identifier_workflows_active_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierWorkflowsActiveParams() *DeleteNodesIdentifierWorkflowsActiveParams {
 	var ()
-	return &DeleteNodesIdentifierWorkflowsActiveParams{}
+	return &DeleteNodesIdentifierWorkflowsActiveParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierWorkflowsActiveParamsWithTimeout creates a new DeleteNodesIdentifierWorkflowsActiveParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierWorkflowsActiveParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierWorkflowsActiveParams {
+	var ()
+	return &DeleteNodesIdentifierWorkflowsActiveParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierWorkflowsActiveParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesIdentifierWorkflowsActiveParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier workflows active params
-func (o *DeleteNodesIdentifierWorkflowsActiveParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierWorkflowsActiveParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierWorkflowsActiveParams) WithIdentifier(identifier string) *DeleteNodesIdentifierWorkflowsActiveParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierWorkflowsActiveParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/delete_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/nodes/delete_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesMacaddressDhcpWhitelistParams() *DeleteNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &DeleteNodesMacaddressDhcpWhitelistParams{}
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new DeleteNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *DeleteNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithMacaddress adds the macaddress to the delete nodes macaddress dhcp whitelist params
-func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param macaddress

--- a/client/nodes/get_nodes_identifier_catalogs_parameters.go
+++ b/client/nodes/get_nodes_identifier_catalogs_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierCatalogsParams() *GetNodesIdentifierCatalogsParams {
 	var ()
-	return &GetNodesIdentifierCatalogsParams{}
+	return &GetNodesIdentifierCatalogsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierCatalogsParamsWithTimeout creates a new GetNodesIdentifierCatalogsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierCatalogsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierCatalogsParams {
+	var ()
+	return &GetNodesIdentifierCatalogsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierCatalogsParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierCatalogsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier catalogs params
-func (o *GetNodesIdentifierCatalogsParams) WithIdentifier(Identifier string) *GetNodesIdentifierCatalogsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierCatalogsParams) WithIdentifier(identifier string) *GetNodesIdentifierCatalogsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierCatalogsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_catalogs_source_parameters.go
+++ b/client/nodes/get_nodes_identifier_catalogs_source_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierCatalogsSourceParams() *GetNodesIdentifierCatalogsSourceParams {
 	var ()
-	return &GetNodesIdentifierCatalogsSourceParams{}
+	return &GetNodesIdentifierCatalogsSourceParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierCatalogsSourceParamsWithTimeout creates a new GetNodesIdentifierCatalogsSourceParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierCatalogsSourceParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierCatalogsSourceParams {
+	var ()
+	return &GetNodesIdentifierCatalogsSourceParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierCatalogsSourceParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type GetNodesIdentifierCatalogsSourceParams struct {
 
 	*/
 	Source string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier catalogs source params
-func (o *GetNodesIdentifierCatalogsSourceParams) WithIdentifier(Identifier string) *GetNodesIdentifierCatalogsSourceParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierCatalogsSourceParams) WithIdentifier(identifier string) *GetNodesIdentifierCatalogsSourceParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithSource adds the source to the get nodes identifier catalogs source params
-func (o *GetNodesIdentifierCatalogsSourceParams) WithSource(Source string) *GetNodesIdentifierCatalogsSourceParams {
-	o.Source = Source
+func (o *GetNodesIdentifierCatalogsSourceParams) WithSource(source string) *GetNodesIdentifierCatalogsSourceParams {
+	o.Source = source
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierCatalogsSourceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_obm_identify_parameters.go
+++ b/client/nodes/get_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierObmIdentifyParams() *GetNodesIdentifierObmIdentifyParams {
 	var ()
-	return &GetNodesIdentifierObmIdentifyParams{}
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierObmIdentifyParamsWithTimeout creates a new GetNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierObmIdentifyParams {
+	var ()
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier obm identify params
-func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *GetNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *GetNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_obm_parameters.go
+++ b/client/nodes/get_nodes_identifier_obm_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierObmParams() *GetNodesIdentifierObmParams {
 	var ()
-	return &GetNodesIdentifierObmParams{}
+	return &GetNodesIdentifierObmParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierObmParamsWithTimeout creates a new GetNodesIdentifierObmParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierObmParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierObmParams {
+	var ()
+	return &GetNodesIdentifierObmParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierObmParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierObmParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier obm params
-func (o *GetNodesIdentifierObmParams) WithIdentifier(Identifier string) *GetNodesIdentifierObmParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierObmParams) WithIdentifier(identifier string) *GetNodesIdentifierObmParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierObmParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_parameters.go
+++ b/client/nodes/get_nodes_identifier_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierParams() *GetNodesIdentifierParams {
 	var ()
-	return &GetNodesIdentifierParams{}
+	return &GetNodesIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierParamsWithTimeout creates a new GetNodesIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierParams {
+	var ()
+	return &GetNodesIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier params
-func (o *GetNodesIdentifierParams) WithIdentifier(Identifier string) *GetNodesIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierParams) WithIdentifier(identifier string) *GetNodesIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_pollers_parameters.go
+++ b/client/nodes/get_nodes_identifier_pollers_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierPollersParams() *GetNodesIdentifierPollersParams {
 	var ()
-	return &GetNodesIdentifierPollersParams{}
+	return &GetNodesIdentifierPollersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierPollersParamsWithTimeout creates a new GetNodesIdentifierPollersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierPollersParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierPollersParams {
+	var ()
+	return &GetNodesIdentifierPollersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierPollersParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierPollersParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier pollers params
-func (o *GetNodesIdentifierPollersParams) WithIdentifier(Identifier string) *GetNodesIdentifierPollersParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierPollersParams) WithIdentifier(identifier string) *GetNodesIdentifierPollersParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierPollersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_tags_parameters.go
+++ b/client/nodes/get_nodes_identifier_tags_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierTagsParams() *GetNodesIdentifierTagsParams {
 	var ()
-	return &GetNodesIdentifierTagsParams{}
+	return &GetNodesIdentifierTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierTagsParamsWithTimeout creates a new GetNodesIdentifierTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierTagsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierTagsParams {
+	var ()
+	return &GetNodesIdentifierTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierTagsParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetNodesIdentifierTagsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier tags params
-func (o *GetNodesIdentifierTagsParams) WithIdentifier(Identifier string) *GetNodesIdentifierTagsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierTagsParams) WithIdentifier(identifier string) *GetNodesIdentifierTagsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_workflows_active_parameters.go
+++ b/client/nodes/get_nodes_identifier_workflows_active_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierWorkflowsActiveParams() *GetNodesIdentifierWorkflowsActiveParams {
 	var ()
-	return &GetNodesIdentifierWorkflowsActiveParams{}
+	return &GetNodesIdentifierWorkflowsActiveParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierWorkflowsActiveParamsWithTimeout creates a new GetNodesIdentifierWorkflowsActiveParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierWorkflowsActiveParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierWorkflowsActiveParams {
+	var ()
+	return &GetNodesIdentifierWorkflowsActiveParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierWorkflowsActiveParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierWorkflowsActiveParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier workflows active params
-func (o *GetNodesIdentifierWorkflowsActiveParams) WithIdentifier(Identifier string) *GetNodesIdentifierWorkflowsActiveParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierWorkflowsActiveParams) WithIdentifier(identifier string) *GetNodesIdentifierWorkflowsActiveParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierWorkflowsActiveParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_identifier_workflows_parameters.go
+++ b/client/nodes/get_nodes_identifier_workflows_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierWorkflowsParams() *GetNodesIdentifierWorkflowsParams {
 	var ()
-	return &GetNodesIdentifierWorkflowsParams{}
+	return &GetNodesIdentifierWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierWorkflowsParamsWithTimeout creates a new GetNodesIdentifierWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierWorkflowsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierWorkflowsParams {
+	var ()
+	return &GetNodesIdentifierWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierWorkflowsParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierWorkflowsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier workflows params
-func (o *GetNodesIdentifierWorkflowsParams) WithIdentifier(Identifier string) *GetNodesIdentifierWorkflowsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierWorkflowsParams) WithIdentifier(identifier string) *GetNodesIdentifierWorkflowsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/get_nodes_parameters.go
+++ b/client/nodes/get_nodes_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetNodesParams() *GetNodesParams {
 
-	return &GetNodesParams{}
+	return &GetNodesParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesParamsWithTimeout creates a new GetNodesParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesParamsWithTimeout(timeout time.Duration) *GetNodesParams {
+
+	return &GetNodesParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesParams contains all the parameters to send to the API endpoint
 for the get nodes operation typically these are written to a http.Request
 */
 type GetNodesParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/nodes/get_skus_identifier_nodes_parameters.go
+++ b/client/nodes/get_skus_identifier_nodes_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetSkusIdentifierNodesParams() *GetSkusIdentifierNodesParams {
 	var ()
-	return &GetSkusIdentifierNodesParams{}
+	return &GetSkusIdentifierNodesParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetSkusIdentifierNodesParamsWithTimeout creates a new GetSkusIdentifierNodesParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetSkusIdentifierNodesParamsWithTimeout(timeout time.Duration) *GetSkusIdentifierNodesParams {
+	var ()
+	return &GetSkusIdentifierNodesParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetSkusIdentifierNodesParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetSkusIdentifierNodesParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get skus identifier nodes params
-func (o *GetSkusIdentifierNodesParams) WithIdentifier(Identifier string) *GetSkusIdentifierNodesParams {
-	o.Identifier = Identifier
+func (o *GetSkusIdentifierNodesParams) WithIdentifier(identifier string) *GetSkusIdentifierNodesParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetSkusIdentifierNodesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/nodes/patch_nodes_identifier_parameters.go
+++ b/client/nodes/patch_nodes_identifier_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchNodesIdentifierParams() *PatchNodesIdentifierParams {
 	var ()
-	return &PatchNodesIdentifierParams{}
+	return &PatchNodesIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchNodesIdentifierParamsWithTimeout creates a new PatchNodesIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchNodesIdentifierParamsWithTimeout(timeout time.Duration) *PatchNodesIdentifierParams {
+	var ()
+	return &PatchNodesIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchNodesIdentifierParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PatchNodesIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch nodes identifier params
-func (o *PatchNodesIdentifierParams) WithBody(Body interface{}) *PatchNodesIdentifierParams {
-	o.Body = Body
+func (o *PatchNodesIdentifierParams) WithBody(body interface{}) *PatchNodesIdentifierParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the patch nodes identifier params
-func (o *PatchNodesIdentifierParams) WithIdentifier(Identifier string) *PatchNodesIdentifierParams {
-	o.Identifier = Identifier
+func (o *PatchNodesIdentifierParams) WithIdentifier(identifier string) *PatchNodesIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchNodesIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/nodes/patch_nodes_identifier_tags_parameters.go
+++ b/client/nodes/patch_nodes_identifier_tags_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchNodesIdentifierTagsParams() *PatchNodesIdentifierTagsParams {
 	var ()
-	return &PatchNodesIdentifierTagsParams{}
+	return &PatchNodesIdentifierTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchNodesIdentifierTagsParamsWithTimeout creates a new PatchNodesIdentifierTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchNodesIdentifierTagsParamsWithTimeout(timeout time.Duration) *PatchNodesIdentifierTagsParams {
+	var ()
+	return &PatchNodesIdentifierTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchNodesIdentifierTagsParams contains all the parameters to send to the API endpoint
@@ -34,23 +50,26 @@ type PatchNodesIdentifierTagsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch nodes identifier tags params
-func (o *PatchNodesIdentifierTagsParams) WithBody(Body interface{}) *PatchNodesIdentifierTagsParams {
-	o.Body = Body
+func (o *PatchNodesIdentifierTagsParams) WithBody(body interface{}) *PatchNodesIdentifierTagsParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the patch nodes identifier tags params
-func (o *PatchNodesIdentifierTagsParams) WithIdentifier(Identifier string) *PatchNodesIdentifierTagsParams {
-	o.Identifier = Identifier
+func (o *PatchNodesIdentifierTagsParams) WithIdentifier(identifier string) *PatchNodesIdentifierTagsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchNodesIdentifierTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/nodes/post_nodes_identifier_obm_identify_parameters.go
+++ b/client/nodes/post_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierObmIdentifyParams() *PostNodesIdentifierObmIdentifyParams {
 	var ()
-	return &PostNodesIdentifierObmIdentifyParams{}
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierObmIdentifyParamsWithTimeout creates a new PostNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierObmIdentifyParams {
+	var ()
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PostNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithBody(Body *bool) *PostNodesIdentifierObmIdentifyParams {
-	o.Body = Body
+func (o *PostNodesIdentifierObmIdentifyParams) WithBody(body *bool) *PostNodesIdentifierObmIdentifyParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *PostNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *PostNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/nodes/post_nodes_identifier_obm_parameters.go
+++ b/client/nodes/post_nodes_identifier_obm_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierObmParams() *PostNodesIdentifierObmParams {
 	var ()
-	return &PostNodesIdentifierObmParams{}
+	return &PostNodesIdentifierObmParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierObmParamsWithTimeout creates a new PostNodesIdentifierObmParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierObmParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierObmParams {
+	var ()
+	return &PostNodesIdentifierObmParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierObmParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PostNodesIdentifierObmParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier obm params
-func (o *PostNodesIdentifierObmParams) WithBody(Body interface{}) *PostNodesIdentifierObmParams {
-	o.Body = Body
+func (o *PostNodesIdentifierObmParams) WithBody(body interface{}) *PostNodesIdentifierObmParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier obm params
-func (o *PostNodesIdentifierObmParams) WithIdentifier(Identifier string) *PostNodesIdentifierObmParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierObmParams) WithIdentifier(identifier string) *PostNodesIdentifierObmParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierObmParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/nodes/post_nodes_identifier_workflows_parameters.go
+++ b/client/nodes/post_nodes_identifier_workflows_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierWorkflowsParams() *PostNodesIdentifierWorkflowsParams {
 	var ()
-	return &PostNodesIdentifierWorkflowsParams{}
+	return &PostNodesIdentifierWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierWorkflowsParamsWithTimeout creates a new PostNodesIdentifierWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierWorkflowsParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierWorkflowsParams {
+	var ()
+	return &PostNodesIdentifierWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierWorkflowsParams contains all the parameters to send to the API endpoint
@@ -36,29 +52,32 @@ type PostNodesIdentifierWorkflowsParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithBody(Body interface{}) *PostNodesIdentifierWorkflowsParams {
-	o.Body = Body
+func (o *PostNodesIdentifierWorkflowsParams) WithBody(body interface{}) *PostNodesIdentifierWorkflowsParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithIdentifier(Identifier string) *PostNodesIdentifierWorkflowsParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierWorkflowsParams) WithIdentifier(identifier string) *PostNodesIdentifierWorkflowsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithName adds the name to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithName(Name string) *PostNodesIdentifierWorkflowsParams {
-	o.Name = Name
+func (o *PostNodesIdentifierWorkflowsParams) WithName(name string) *PostNodesIdentifierWorkflowsParams {
+	o.Name = name
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/nodes/post_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/nodes/post_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesMacaddressDhcpWhitelistParams() *PostNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &PostNodesMacaddressDhcpWhitelistParams{}
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new PostNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *PostNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -31,23 +47,26 @@ type PostNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(Body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Body = Body
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Body = body
 	return o
 }
 
 // WithMacaddress adds the macaddress to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/nodes/post_nodes_parameters.go
+++ b/client/nodes/post_nodes_parameters.go
@@ -4,8 +4,11 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesParams() *PostNodesParams {
 	var ()
-	return &PostNodesParams{}
+	return &PostNodesParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesParamsWithTimeout creates a new PostNodesParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesParamsWithTimeout(timeout time.Duration) *PostNodesParams {
+	var ()
+	return &PostNodesParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type PostNodesParams struct {
 
 	*/
 	Identifiers interface{}
+
+	timeout time.Duration
 }
 
 // WithIdentifiers adds the identifiers to the post nodes params
-func (o *PostNodesParams) WithIdentifiers(Identifiers interface{}) *PostNodesParams {
-	o.Identifiers = Identifiers
+func (o *PostNodesParams) WithIdentifiers(identifiers interface{}) *PostNodesParams {
+	o.Identifiers = identifiers
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Identifiers); err != nil {

--- a/client/obm/get_nodes_identifier_obm_identify_parameters.go
+++ b/client/obm/get_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package obm
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierObmIdentifyParams() *GetNodesIdentifierObmIdentifyParams {
 	var ()
-	return &GetNodesIdentifierObmIdentifyParams{}
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierObmIdentifyParamsWithTimeout creates a new GetNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierObmIdentifyParams {
+	var ()
+	return &GetNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier obm identify params
-func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *GetNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *GetNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/obm/get_nodes_identifier_obm_parameters.go
+++ b/client/obm/get_nodes_identifier_obm_parameters.go
@@ -4,8 +4,11 @@ package obm
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierObmParams() *GetNodesIdentifierObmParams {
 	var ()
-	return &GetNodesIdentifierObmParams{}
+	return &GetNodesIdentifierObmParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierObmParamsWithTimeout creates a new GetNodesIdentifierObmParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierObmParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierObmParams {
+	var ()
+	return &GetNodesIdentifierObmParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierObmParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierObmParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier obm params
-func (o *GetNodesIdentifierObmParams) WithIdentifier(Identifier string) *GetNodesIdentifierObmParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierObmParams) WithIdentifier(identifier string) *GetNodesIdentifierObmParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierObmParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/obm/post_nodes_identifier_obm_identify_parameters.go
+++ b/client/obm/post_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package obm
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierObmIdentifyParams() *PostNodesIdentifierObmIdentifyParams {
 	var ()
-	return &PostNodesIdentifierObmIdentifyParams{}
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierObmIdentifyParamsWithTimeout creates a new PostNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierObmIdentifyParams {
+	var ()
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PostNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithBody(Body *bool) *PostNodesIdentifierObmIdentifyParams {
-	o.Body = Body
+func (o *PostNodesIdentifierObmIdentifyParams) WithBody(body *bool) *PostNodesIdentifierObmIdentifyParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *PostNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *PostNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/obm/post_nodes_identifier_obm_parameters.go
+++ b/client/obm/post_nodes_identifier_obm_parameters.go
@@ -4,8 +4,11 @@ package obm
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierObmParams() *PostNodesIdentifierObmParams {
 	var ()
-	return &PostNodesIdentifierObmParams{}
+	return &PostNodesIdentifierObmParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierObmParamsWithTimeout creates a new PostNodesIdentifierObmParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierObmParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierObmParams {
+	var ()
+	return &PostNodesIdentifierObmParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierObmParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PostNodesIdentifierObmParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier obm params
-func (o *PostNodesIdentifierObmParams) WithBody(Body interface{}) *PostNodesIdentifierObmParams {
-	o.Body = Body
+func (o *PostNodesIdentifierObmParams) WithBody(body interface{}) *PostNodesIdentifierObmParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier obm params
-func (o *PostNodesIdentifierObmParams) WithIdentifier(Identifier string) *PostNodesIdentifierObmParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierObmParams) WithIdentifier(identifier string) *PostNodesIdentifierObmParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierObmParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/obms/get_obms_library_identifier_parameters.go
+++ b/client/obms/get_obms_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package obms
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetObmsLibraryIdentifierParams() *GetObmsLibraryIdentifierParams {
 	var ()
-	return &GetObmsLibraryIdentifierParams{}
+	return &GetObmsLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetObmsLibraryIdentifierParamsWithTimeout creates a new GetObmsLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetObmsLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetObmsLibraryIdentifierParams {
+	var ()
+	return &GetObmsLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetObmsLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetObmsLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get obms library identifier params
-func (o *GetObmsLibraryIdentifierParams) WithIdentifier(Identifier string) *GetObmsLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetObmsLibraryIdentifierParams) WithIdentifier(identifier string) *GetObmsLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetObmsLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/obms/get_obms_library_parameters.go
+++ b/client/obms/get_obms_library_parameters.go
@@ -4,8 +4,11 @@ package obms
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetObmsLibraryParams() *GetObmsLibraryParams {
 
-	return &GetObmsLibraryParams{}
+	return &GetObmsLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetObmsLibraryParamsWithTimeout creates a new GetObmsLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetObmsLibraryParamsWithTimeout(timeout time.Duration) *GetObmsLibraryParams {
+
+	return &GetObmsLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetObmsLibraryParams contains all the parameters to send to the API endpoint
 for the get obms library operation typically these are written to a http.Request
 */
 type GetObmsLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetObmsLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/patch/patch_config_parameters.go
+++ b/client/patch/patch_config_parameters.go
@@ -4,8 +4,11 @@ package patch
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchConfigParams() *PatchConfigParams {
 	var ()
-	return &PatchConfigParams{}
+	return &PatchConfigParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchConfigParamsWithTimeout creates a new PatchConfigParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchConfigParamsWithTimeout(timeout time.Duration) *PatchConfigParams {
+	var ()
+	return &PatchConfigParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchConfigParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PatchConfigParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch config params
-func (o *PatchConfigParams) WithBody(Body interface{}) *PatchConfigParams {
-	o.Body = Body
+func (o *PatchConfigParams) WithBody(body interface{}) *PatchConfigParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchConfigParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/patch/patch_nodes_identifier_parameters.go
+++ b/client/patch/patch_nodes_identifier_parameters.go
@@ -4,8 +4,11 @@ package patch
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchNodesIdentifierParams() *PatchNodesIdentifierParams {
 	var ()
-	return &PatchNodesIdentifierParams{}
+	return &PatchNodesIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchNodesIdentifierParamsWithTimeout creates a new PatchNodesIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchNodesIdentifierParamsWithTimeout(timeout time.Duration) *PatchNodesIdentifierParams {
+	var ()
+	return &PatchNodesIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchNodesIdentifierParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PatchNodesIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch nodes identifier params
-func (o *PatchNodesIdentifierParams) WithBody(Body interface{}) *PatchNodesIdentifierParams {
-	o.Body = Body
+func (o *PatchNodesIdentifierParams) WithBody(body interface{}) *PatchNodesIdentifierParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the patch nodes identifier params
-func (o *PatchNodesIdentifierParams) WithIdentifier(Identifier string) *PatchNodesIdentifierParams {
-	o.Identifier = Identifier
+func (o *PatchNodesIdentifierParams) WithIdentifier(identifier string) *PatchNodesIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchNodesIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/patch/patch_nodes_identifier_tags_parameters.go
+++ b/client/patch/patch_nodes_identifier_tags_parameters.go
@@ -4,8 +4,11 @@ package patch
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchNodesIdentifierTagsParams() *PatchNodesIdentifierTagsParams {
 	var ()
-	return &PatchNodesIdentifierTagsParams{}
+	return &PatchNodesIdentifierTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchNodesIdentifierTagsParamsWithTimeout creates a new PatchNodesIdentifierTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchNodesIdentifierTagsParamsWithTimeout(timeout time.Duration) *PatchNodesIdentifierTagsParams {
+	var ()
+	return &PatchNodesIdentifierTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchNodesIdentifierTagsParams contains all the parameters to send to the API endpoint
@@ -34,23 +50,26 @@ type PatchNodesIdentifierTagsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch nodes identifier tags params
-func (o *PatchNodesIdentifierTagsParams) WithBody(Body interface{}) *PatchNodesIdentifierTagsParams {
-	o.Body = Body
+func (o *PatchNodesIdentifierTagsParams) WithBody(body interface{}) *PatchNodesIdentifierTagsParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the patch nodes identifier tags params
-func (o *PatchNodesIdentifierTagsParams) WithIdentifier(Identifier string) *PatchNodesIdentifierTagsParams {
-	o.Identifier = Identifier
+func (o *PatchNodesIdentifierTagsParams) WithIdentifier(identifier string) *PatchNodesIdentifierTagsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchNodesIdentifierTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/patch/patch_pollers_identifier_parameters.go
+++ b/client/patch/patch_pollers_identifier_parameters.go
@@ -4,8 +4,11 @@ package patch
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchPollersIdentifierParams() *PatchPollersIdentifierParams {
 	var ()
-	return &PatchPollersIdentifierParams{}
+	return &PatchPollersIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchPollersIdentifierParamsWithTimeout creates a new PatchPollersIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchPollersIdentifierParamsWithTimeout(timeout time.Duration) *PatchPollersIdentifierParams {
+	var ()
+	return &PatchPollersIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchPollersIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PatchPollersIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the patch pollers identifier params
-func (o *PatchPollersIdentifierParams) WithIdentifier(Identifier string) *PatchPollersIdentifierParams {
-	o.Identifier = Identifier
+func (o *PatchPollersIdentifierParams) WithIdentifier(identifier string) *PatchPollersIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchPollersIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/patch/patch_skus_identifier_parameters.go
+++ b/client/patch/patch_skus_identifier_parameters.go
@@ -4,8 +4,11 @@ package patch
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchSkusIdentifierParams() *PatchSkusIdentifierParams {
 	var ()
-	return &PatchSkusIdentifierParams{}
+	return &PatchSkusIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchSkusIdentifierParamsWithTimeout creates a new PatchSkusIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchSkusIdentifierParamsWithTimeout(timeout time.Duration) *PatchSkusIdentifierParams {
+	var ()
+	return &PatchSkusIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchSkusIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PatchSkusIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the patch skus identifier params
-func (o *PatchSkusIdentifierParams) WithIdentifier(Identifier string) *PatchSkusIdentifierParams {
-	o.Identifier = Identifier
+func (o *PatchSkusIdentifierParams) WithIdentifier(identifier string) *PatchSkusIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchSkusIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/pollers/delete_pollers_identifier_parameters.go
+++ b/client/pollers/delete_pollers_identifier_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeletePollersIdentifierParams() *DeletePollersIdentifierParams {
 	var ()
-	return &DeletePollersIdentifierParams{}
+	return &DeletePollersIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeletePollersIdentifierParamsWithTimeout creates a new DeletePollersIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeletePollersIdentifierParamsWithTimeout(timeout time.Duration) *DeletePollersIdentifierParams {
+	var ()
+	return &DeletePollersIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeletePollersIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type DeletePollersIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete pollers identifier params
-func (o *DeletePollersIdentifierParams) WithIdentifier(Identifier string) *DeletePollersIdentifierParams {
-	o.Identifier = Identifier
+func (o *DeletePollersIdentifierParams) WithIdentifier(identifier string) *DeletePollersIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeletePollersIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/pollers/get_nodes_identifier_pollers_parameters.go
+++ b/client/pollers/get_nodes_identifier_pollers_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierPollersParams() *GetNodesIdentifierPollersParams {
 	var ()
-	return &GetNodesIdentifierPollersParams{}
+	return &GetNodesIdentifierPollersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierPollersParamsWithTimeout creates a new GetNodesIdentifierPollersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierPollersParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierPollersParams {
+	var ()
+	return &GetNodesIdentifierPollersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierPollersParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierPollersParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier pollers params
-func (o *GetNodesIdentifierPollersParams) WithIdentifier(Identifier string) *GetNodesIdentifierPollersParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierPollersParams) WithIdentifier(identifier string) *GetNodesIdentifierPollersParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierPollersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/pollers/get_pollers_identifier_parameters.go
+++ b/client/pollers/get_pollers_identifier_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetPollersIdentifierParams() *GetPollersIdentifierParams {
 	var ()
-	return &GetPollersIdentifierParams{}
+	return &GetPollersIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersIdentifierParamsWithTimeout creates a new GetPollersIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersIdentifierParamsWithTimeout(timeout time.Duration) *GetPollersIdentifierParams {
+	var ()
+	return &GetPollersIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetPollersIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get pollers identifier params
-func (o *GetPollersIdentifierParams) WithIdentifier(Identifier string) *GetPollersIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetPollersIdentifierParams) WithIdentifier(identifier string) *GetPollersIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/pollers/get_pollers_library_identifier_parameters.go
+++ b/client/pollers/get_pollers_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetPollersLibraryIdentifierParams() *GetPollersLibraryIdentifierParams {
 	var ()
-	return &GetPollersLibraryIdentifierParams{}
+	return &GetPollersLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersLibraryIdentifierParamsWithTimeout creates a new GetPollersLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetPollersLibraryIdentifierParams {
+	var ()
+	return &GetPollersLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetPollersLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get pollers library identifier params
-func (o *GetPollersLibraryIdentifierParams) WithIdentifier(Identifier string) *GetPollersLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetPollersLibraryIdentifierParams) WithIdentifier(identifier string) *GetPollersLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/pollers/get_pollers_library_parameters.go
+++ b/client/pollers/get_pollers_library_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetPollersLibraryParams() *GetPollersLibraryParams {
 
-	return &GetPollersLibraryParams{}
+	return &GetPollersLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersLibraryParamsWithTimeout creates a new GetPollersLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersLibraryParamsWithTimeout(timeout time.Duration) *GetPollersLibraryParams {
+
+	return &GetPollersLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersLibraryParams contains all the parameters to send to the API endpoint
 for the get pollers library operation typically these are written to a http.Request
 */
 type GetPollersLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/pollers/get_pollers_parameters.go
+++ b/client/pollers/get_pollers_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetPollersParams() *GetPollersParams {
 
-	return &GetPollersParams{}
+	return &GetPollersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersParamsWithTimeout creates a new GetPollersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersParamsWithTimeout(timeout time.Duration) *GetPollersParams {
+
+	return &GetPollersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersParams contains all the parameters to send to the API endpoint
 for the get pollers operation typically these are written to a http.Request
 */
 type GetPollersParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/pollers/patch_pollers_identifier_parameters.go
+++ b/client/pollers/patch_pollers_identifier_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchPollersIdentifierParams() *PatchPollersIdentifierParams {
 	var ()
-	return &PatchPollersIdentifierParams{}
+	return &PatchPollersIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchPollersIdentifierParamsWithTimeout creates a new PatchPollersIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchPollersIdentifierParamsWithTimeout(timeout time.Duration) *PatchPollersIdentifierParams {
+	var ()
+	return &PatchPollersIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchPollersIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PatchPollersIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the patch pollers identifier params
-func (o *PatchPollersIdentifierParams) WithIdentifier(Identifier string) *PatchPollersIdentifierParams {
-	o.Identifier = Identifier
+func (o *PatchPollersIdentifierParams) WithIdentifier(identifier string) *PatchPollersIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchPollersIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/pollers/post_pollers_parameters.go
+++ b/client/pollers/post_pollers_parameters.go
@@ -4,8 +4,11 @@ package pollers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewPostPollersParams() *PostPollersParams {
 
-	return &PostPollersParams{}
+	return &PostPollersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostPollersParamsWithTimeout creates a new PostPollersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostPollersParamsWithTimeout(timeout time.Duration) *PostPollersParams {
+
+	return &PostPollersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostPollersParams contains all the parameters to send to the API endpoint
 for the post pollers operation typically these are written to a http.Request
 */
 type PostPollersParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostPollersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/post/post_client.go
+++ b/client/post/post_client.go
@@ -318,7 +318,7 @@ PutFilesFileidentifier puts file based on filename
 Put file based on filename, returns the uuid of the stored file.
 
 */
-func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierOK, error) {
+func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, authInfo runtime.ClientAuthInfoWriter) (*PutFilesFileidentifierCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewPutFilesFileidentifierParams()
@@ -338,7 +338,7 @@ func (a *Client) PutFilesFileidentifier(params *PutFilesFileidentifierParams, au
 	if err != nil {
 		return nil, err
 	}
-	return result.(*PutFilesFileidentifierOK), nil
+	return result.(*PutFilesFileidentifierCreated), nil
 }
 
 // SetTransport changes the transport on the client

--- a/client/post/post_lookups_id_parameters.go
+++ b/client/post/post_lookups_id_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostLookupsIDParams() *PostLookupsIDParams {
 	var ()
-	return &PostLookupsIDParams{}
+	return &PostLookupsIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostLookupsIDParamsWithTimeout creates a new PostLookupsIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostLookupsIDParamsWithTimeout(timeout time.Duration) *PostLookupsIDParams {
+	var ()
+	return &PostLookupsIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostLookupsIDParams contains all the parameters to send to the API endpoint
@@ -32,23 +48,26 @@ type PostLookupsIDParams struct {
 
 	*/
 	ID string
+
+	timeout time.Duration
 }
 
 // WithContent adds the content to the post lookups ID params
-func (o *PostLookupsIDParams) WithContent(Content interface{}) *PostLookupsIDParams {
-	o.Content = Content
+func (o *PostLookupsIDParams) WithContent(content interface{}) *PostLookupsIDParams {
+	o.Content = content
 	return o
 }
 
 // WithID adds the id to the post lookups ID params
-func (o *PostLookupsIDParams) WithID(ID string) *PostLookupsIDParams {
-	o.ID = ID
+func (o *PostLookupsIDParams) WithID(id string) *PostLookupsIDParams {
+	o.ID = id
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostLookupsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Content); err != nil {

--- a/client/post/post_lookups_parameters.go
+++ b/client/post/post_lookups_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostLookupsParams() *PostLookupsParams {
 	var ()
-	return &PostLookupsParams{}
+	return &PostLookupsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostLookupsParamsWithTimeout creates a new PostLookupsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostLookupsParamsWithTimeout(timeout time.Duration) *PostLookupsParams {
+	var ()
+	return &PostLookupsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostLookupsParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type PostLookupsParams struct {
 
 	*/
 	Content interface{}
+
+	timeout time.Duration
 }
 
 // WithContent adds the content to the post lookups params
-func (o *PostLookupsParams) WithContent(Content interface{}) *PostLookupsParams {
-	o.Content = Content
+func (o *PostLookupsParams) WithContent(content interface{}) *PostLookupsParams {
+	o.Content = content
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostLookupsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Content); err != nil {

--- a/client/post/post_nodes_identifier_obm_identify_parameters.go
+++ b/client/post/post_nodes_identifier_obm_identify_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierObmIdentifyParams() *PostNodesIdentifierObmIdentifyParams {
 	var ()
-	return &PostNodesIdentifierObmIdentifyParams{}
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierObmIdentifyParamsWithTimeout creates a new PostNodesIdentifierObmIdentifyParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierObmIdentifyParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierObmIdentifyParams {
+	var ()
+	return &PostNodesIdentifierObmIdentifyParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierObmIdentifyParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PostNodesIdentifierObmIdentifyParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithBody(Body *bool) *PostNodesIdentifierObmIdentifyParams {
-	o.Body = Body
+func (o *PostNodesIdentifierObmIdentifyParams) WithBody(body *bool) *PostNodesIdentifierObmIdentifyParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier obm identify params
-func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(Identifier string) *PostNodesIdentifierObmIdentifyParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierObmIdentifyParams) WithIdentifier(identifier string) *PostNodesIdentifierObmIdentifyParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierObmIdentifyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/post/post_nodes_identifier_obm_parameters.go
+++ b/client/post/post_nodes_identifier_obm_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierObmParams() *PostNodesIdentifierObmParams {
 	var ()
-	return &PostNodesIdentifierObmParams{}
+	return &PostNodesIdentifierObmParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierObmParamsWithTimeout creates a new PostNodesIdentifierObmParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierObmParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierObmParams {
+	var ()
+	return &PostNodesIdentifierObmParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierObmParams contains all the parameters to send to the API endpoint
@@ -35,23 +51,26 @@ type PostNodesIdentifierObmParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier obm params
-func (o *PostNodesIdentifierObmParams) WithBody(Body interface{}) *PostNodesIdentifierObmParams {
-	o.Body = Body
+func (o *PostNodesIdentifierObmParams) WithBody(body interface{}) *PostNodesIdentifierObmParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier obm params
-func (o *PostNodesIdentifierObmParams) WithIdentifier(Identifier string) *PostNodesIdentifierObmParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierObmParams) WithIdentifier(identifier string) *PostNodesIdentifierObmParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierObmParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/post/post_nodes_identifier_workflows_parameters.go
+++ b/client/post/post_nodes_identifier_workflows_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierWorkflowsParams() *PostNodesIdentifierWorkflowsParams {
 	var ()
-	return &PostNodesIdentifierWorkflowsParams{}
+	return &PostNodesIdentifierWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierWorkflowsParamsWithTimeout creates a new PostNodesIdentifierWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierWorkflowsParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierWorkflowsParams {
+	var ()
+	return &PostNodesIdentifierWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierWorkflowsParams contains all the parameters to send to the API endpoint
@@ -36,29 +52,32 @@ type PostNodesIdentifierWorkflowsParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithBody(Body interface{}) *PostNodesIdentifierWorkflowsParams {
-	o.Body = Body
+func (o *PostNodesIdentifierWorkflowsParams) WithBody(body interface{}) *PostNodesIdentifierWorkflowsParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithIdentifier(Identifier string) *PostNodesIdentifierWorkflowsParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierWorkflowsParams) WithIdentifier(identifier string) *PostNodesIdentifierWorkflowsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithName adds the name to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithName(Name string) *PostNodesIdentifierWorkflowsParams {
-	o.Name = Name
+func (o *PostNodesIdentifierWorkflowsParams) WithName(name string) *PostNodesIdentifierWorkflowsParams {
+	o.Name = name
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/post/post_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/post/post_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesMacaddressDhcpWhitelistParams() *PostNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &PostNodesMacaddressDhcpWhitelistParams{}
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new PostNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *PostNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -31,23 +47,26 @@ type PostNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(Body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Body = Body
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Body = body
 	return o
 }
 
 // WithMacaddress adds the macaddress to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/post/post_nodes_parameters.go
+++ b/client/post/post_nodes_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesParams() *PostNodesParams {
 	var ()
-	return &PostNodesParams{}
+	return &PostNodesParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesParamsWithTimeout creates a new PostNodesParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesParamsWithTimeout(timeout time.Duration) *PostNodesParams {
+	var ()
+	return &PostNodesParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type PostNodesParams struct {
 
 	*/
 	Identifiers interface{}
+
+	timeout time.Duration
 }
 
 // WithIdentifiers adds the identifiers to the post nodes params
-func (o *PostNodesParams) WithIdentifiers(Identifiers interface{}) *PostNodesParams {
-	o.Identifiers = Identifiers
+func (o *PostNodesParams) WithIdentifiers(identifiers interface{}) *PostNodesParams {
+	o.Identifiers = identifiers
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Identifiers); err != nil {

--- a/client/post/post_skus_parameters.go
+++ b/client/post/post_skus_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewPostSkusParams() *PostSkusParams {
 
-	return &PostSkusParams{}
+	return &PostSkusParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostSkusParamsWithTimeout creates a new PostSkusParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostSkusParamsWithTimeout(timeout time.Duration) *PostSkusParams {
+
+	return &PostSkusParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostSkusParams contains all the parameters to send to the API endpoint
 for the post skus operation typically these are written to a http.Request
 */
 type PostSkusParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostSkusParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/post/post_tags_parameters.go
+++ b/client/post/post_tags_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostTagsParams() *PostTagsParams {
 	var ()
-	return &PostTagsParams{}
+	return &PostTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostTagsParamsWithTimeout creates a new PostTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostTagsParamsWithTimeout(timeout time.Duration) *PostTagsParams {
+	var ()
+	return &PostTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostTagsParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PostTagsParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post tags params
-func (o *PostTagsParams) WithBody(Body interface{}) *PostTagsParams {
-	o.Body = Body
+func (o *PostTagsParams) WithBody(body interface{}) *PostTagsParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/post/post_workflows_parameters.go
+++ b/client/post/post_workflows_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostWorkflowsParams() *PostWorkflowsParams {
 	var ()
-	return &PostWorkflowsParams{}
+	return &PostWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostWorkflowsParamsWithTimeout creates a new PostWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostWorkflowsParamsWithTimeout(timeout time.Duration) *PostWorkflowsParams {
+	var ()
+	return &PostWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostWorkflowsParams contains all the parameters to send to the API endpoint
@@ -30,23 +46,26 @@ type PostWorkflowsParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post workflows params
-func (o *PostWorkflowsParams) WithBody(Body interface{}) *PostWorkflowsParams {
-	o.Body = Body
+func (o *PostWorkflowsParams) WithBody(body interface{}) *PostWorkflowsParams {
+	o.Body = body
 	return o
 }
 
 // WithName adds the name to the post workflows params
-func (o *PostWorkflowsParams) WithName(Name string) *PostWorkflowsParams {
-	o.Name = Name
+func (o *PostWorkflowsParams) WithName(name string) *PostWorkflowsParams {
+	o.Name = name
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/post/put_files_fileidentifier_parameters.go
+++ b/client/post/put_files_fileidentifier_parameters.go
@@ -4,8 +4,11 @@ package post
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutFilesFileidentifierParams() *PutFilesFileidentifierParams {
 	var ()
-	return &PutFilesFileidentifierParams{}
+	return &PutFilesFileidentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutFilesFileidentifierParamsWithTimeout creates a new PutFilesFileidentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutFilesFileidentifierParamsWithTimeout(timeout time.Duration) *PutFilesFileidentifierParams {
+	var ()
+	return &PutFilesFileidentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutFilesFileidentifierParams contains all the parameters to send to the API endpoint
@@ -27,17 +43,20 @@ type PutFilesFileidentifierParams struct {
 
 	*/
 	Fileidentifier string
+
+	timeout time.Duration
 }
 
 // WithFileidentifier adds the fileidentifier to the put files fileidentifier params
-func (o *PutFilesFileidentifierParams) WithFileidentifier(Fileidentifier string) *PutFilesFileidentifierParams {
-	o.Fileidentifier = Fileidentifier
+func (o *PutFilesFileidentifierParams) WithFileidentifier(fileidentifier string) *PutFilesFileidentifierParams {
+	o.Fileidentifier = fileidentifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutFilesFileidentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param fileidentifier

--- a/client/profiles/delete_skus_identifier_parameters.go
+++ b/client/profiles/delete_skus_identifier_parameters.go
@@ -4,8 +4,11 @@ package profiles
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteSkusIdentifierParams() *DeleteSkusIdentifierParams {
 	var ()
-	return &DeleteSkusIdentifierParams{}
+	return &DeleteSkusIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteSkusIdentifierParamsWithTimeout creates a new DeleteSkusIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteSkusIdentifierParamsWithTimeout(timeout time.Duration) *DeleteSkusIdentifierParams {
+	var ()
+	return &DeleteSkusIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteSkusIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type DeleteSkusIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete skus identifier params
-func (o *DeleteSkusIdentifierParams) WithIdentifier(Identifier string) *DeleteSkusIdentifierParams {
-	o.Identifier = Identifier
+func (o *DeleteSkusIdentifierParams) WithIdentifier(identifier string) *DeleteSkusIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteSkusIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/profiles/get_profiles_library_identifier_parameters.go
+++ b/client/profiles/get_profiles_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package profiles
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetProfilesLibraryIdentifierParams() *GetProfilesLibraryIdentifierParams {
 	var ()
-	return &GetProfilesLibraryIdentifierParams{}
+	return &GetProfilesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetProfilesLibraryIdentifierParamsWithTimeout creates a new GetProfilesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetProfilesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetProfilesLibraryIdentifierParams {
+	var ()
+	return &GetProfilesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetProfilesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetProfilesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get profiles library identifier params
-func (o *GetProfilesLibraryIdentifierParams) WithIdentifier(Identifier string) *GetProfilesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetProfilesLibraryIdentifierParams) WithIdentifier(identifier string) *GetProfilesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetProfilesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/profiles/get_profiles_library_parameters.go
+++ b/client/profiles/get_profiles_library_parameters.go
@@ -4,8 +4,11 @@ package profiles
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetProfilesLibraryParams() *GetProfilesLibraryParams {
 
-	return &GetProfilesLibraryParams{}
+	return &GetProfilesLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetProfilesLibraryParamsWithTimeout creates a new GetProfilesLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetProfilesLibraryParamsWithTimeout(timeout time.Duration) *GetProfilesLibraryParams {
+
+	return &GetProfilesLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetProfilesLibraryParams contains all the parameters to send to the API endpoint
 for the get profiles library operation typically these are written to a http.Request
 */
 type GetProfilesLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetProfilesLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/profiles/put_profiles_library_identifier_parameters.go
+++ b/client/profiles/put_profiles_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package profiles
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutProfilesLibraryIdentifierParams() *PutProfilesLibraryIdentifierParams {
 	var ()
-	return &PutProfilesLibraryIdentifierParams{}
+	return &PutProfilesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutProfilesLibraryIdentifierParamsWithTimeout creates a new PutProfilesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutProfilesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *PutProfilesLibraryIdentifierParams {
+	var ()
+	return &PutProfilesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutProfilesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PutProfilesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the put profiles library identifier params
-func (o *PutProfilesLibraryIdentifierParams) WithIdentifier(Identifier string) *PutProfilesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *PutProfilesLibraryIdentifierParams) WithIdentifier(identifier string) *PutProfilesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutProfilesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/put/delete_skus_identifier_parameters.go
+++ b/client/put/delete_skus_identifier_parameters.go
@@ -4,8 +4,11 @@ package put
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteSkusIdentifierParams() *DeleteSkusIdentifierParams {
 	var ()
-	return &DeleteSkusIdentifierParams{}
+	return &DeleteSkusIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteSkusIdentifierParamsWithTimeout creates a new DeleteSkusIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteSkusIdentifierParamsWithTimeout(timeout time.Duration) *DeleteSkusIdentifierParams {
+	var ()
+	return &DeleteSkusIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteSkusIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type DeleteSkusIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete skus identifier params
-func (o *DeleteSkusIdentifierParams) WithIdentifier(Identifier string) *DeleteSkusIdentifierParams {
-	o.Identifier = Identifier
+func (o *DeleteSkusIdentifierParams) WithIdentifier(identifier string) *DeleteSkusIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteSkusIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/put/put_profiles_library_identifier_parameters.go
+++ b/client/put/put_profiles_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package put
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutProfilesLibraryIdentifierParams() *PutProfilesLibraryIdentifierParams {
 	var ()
-	return &PutProfilesLibraryIdentifierParams{}
+	return &PutProfilesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutProfilesLibraryIdentifierParamsWithTimeout creates a new PutProfilesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutProfilesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *PutProfilesLibraryIdentifierParams {
+	var ()
+	return &PutProfilesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutProfilesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PutProfilesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the put profiles library identifier params
-func (o *PutProfilesLibraryIdentifierParams) WithIdentifier(Identifier string) *PutProfilesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *PutProfilesLibraryIdentifierParams) WithIdentifier(identifier string) *PutProfilesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutProfilesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/put/put_templates_library_identifier_parameters.go
+++ b/client/put/put_templates_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package put
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutTemplatesLibraryIdentifierParams() *PutTemplatesLibraryIdentifierParams {
 	var ()
-	return &PutTemplatesLibraryIdentifierParams{}
+	return &PutTemplatesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutTemplatesLibraryIdentifierParamsWithTimeout creates a new PutTemplatesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutTemplatesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *PutTemplatesLibraryIdentifierParams {
+	var ()
+	return &PutTemplatesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutTemplatesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PutTemplatesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the put templates library identifier params
-func (o *PutTemplatesLibraryIdentifierParams) WithIdentifier(Identifier string) *PutTemplatesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *PutTemplatesLibraryIdentifierParams) WithIdentifier(identifier string) *PutTemplatesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutTemplatesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/put/put_workflows_parameters.go
+++ b/client/put/put_workflows_parameters.go
@@ -4,8 +4,11 @@ package put
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutWorkflowsParams() *PutWorkflowsParams {
 	var ()
-	return &PutWorkflowsParams{}
+	return &PutWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutWorkflowsParamsWithTimeout creates a new PutWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutWorkflowsParamsWithTimeout(timeout time.Duration) *PutWorkflowsParams {
+	var ()
+	return &PutWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutWorkflowsParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PutWorkflowsParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the put workflows params
-func (o *PutWorkflowsParams) WithBody(Body interface{}) *PutWorkflowsParams {
-	o.Body = Body
+func (o *PutWorkflowsParams) WithBody(body interface{}) *PutWorkflowsParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/put/put_workflows_tasks_parameters.go
+++ b/client/put/put_workflows_tasks_parameters.go
@@ -4,8 +4,11 @@ package put
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutWorkflowsTasksParams() *PutWorkflowsTasksParams {
 	var ()
-	return &PutWorkflowsTasksParams{}
+	return &PutWorkflowsTasksParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutWorkflowsTasksParamsWithTimeout creates a new PutWorkflowsTasksParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutWorkflowsTasksParamsWithTimeout(timeout time.Duration) *PutWorkflowsTasksParams {
+	var ()
+	return &PutWorkflowsTasksParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutWorkflowsTasksParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PutWorkflowsTasksParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the put workflows tasks params
-func (o *PutWorkflowsTasksParams) WithBody(Body interface{}) *PutWorkflowsTasksParams {
-	o.Body = Body
+func (o *PutWorkflowsTasksParams) WithBody(body interface{}) *PutWorkflowsTasksParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutWorkflowsTasksParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/skus/get_skus_identifier_nodes_parameters.go
+++ b/client/skus/get_skus_identifier_nodes_parameters.go
@@ -4,8 +4,11 @@ package skus
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetSkusIdentifierNodesParams() *GetSkusIdentifierNodesParams {
 	var ()
-	return &GetSkusIdentifierNodesParams{}
+	return &GetSkusIdentifierNodesParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetSkusIdentifierNodesParamsWithTimeout creates a new GetSkusIdentifierNodesParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetSkusIdentifierNodesParamsWithTimeout(timeout time.Duration) *GetSkusIdentifierNodesParams {
+	var ()
+	return &GetSkusIdentifierNodesParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetSkusIdentifierNodesParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetSkusIdentifierNodesParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get skus identifier nodes params
-func (o *GetSkusIdentifierNodesParams) WithIdentifier(Identifier string) *GetSkusIdentifierNodesParams {
-	o.Identifier = Identifier
+func (o *GetSkusIdentifierNodesParams) WithIdentifier(identifier string) *GetSkusIdentifierNodesParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetSkusIdentifierNodesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/skus/get_skus_identifier_parameters.go
+++ b/client/skus/get_skus_identifier_parameters.go
@@ -4,8 +4,11 @@ package skus
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetSkusIdentifierParams() *GetSkusIdentifierParams {
 	var ()
-	return &GetSkusIdentifierParams{}
+	return &GetSkusIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetSkusIdentifierParamsWithTimeout creates a new GetSkusIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetSkusIdentifierParamsWithTimeout(timeout time.Duration) *GetSkusIdentifierParams {
+	var ()
+	return &GetSkusIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetSkusIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetSkusIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get skus identifier params
-func (o *GetSkusIdentifierParams) WithIdentifier(Identifier string) *GetSkusIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetSkusIdentifierParams) WithIdentifier(identifier string) *GetSkusIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetSkusIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/skus/get_skus_parameters.go
+++ b/client/skus/get_skus_parameters.go
@@ -4,8 +4,11 @@ package skus
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetSkusParams() *GetSkusParams {
 
-	return &GetSkusParams{}
+	return &GetSkusParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetSkusParamsWithTimeout creates a new GetSkusParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetSkusParamsWithTimeout(timeout time.Duration) *GetSkusParams {
+
+	return &GetSkusParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetSkusParams contains all the parameters to send to the API endpoint
 for the get skus operation typically these are written to a http.Request
 */
 type GetSkusParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetSkusParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/skus/patch_skus_identifier_parameters.go
+++ b/client/skus/patch_skus_identifier_parameters.go
@@ -4,8 +4,11 @@ package skus
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchSkusIdentifierParams() *PatchSkusIdentifierParams {
 	var ()
-	return &PatchSkusIdentifierParams{}
+	return &PatchSkusIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchSkusIdentifierParamsWithTimeout creates a new PatchSkusIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchSkusIdentifierParamsWithTimeout(timeout time.Duration) *PatchSkusIdentifierParams {
+	var ()
+	return &PatchSkusIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchSkusIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PatchSkusIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the patch skus identifier params
-func (o *PatchSkusIdentifierParams) WithIdentifier(Identifier string) *PatchSkusIdentifierParams {
-	o.Identifier = Identifier
+func (o *PatchSkusIdentifierParams) WithIdentifier(identifier string) *PatchSkusIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchSkusIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/skus/post_skus_parameters.go
+++ b/client/skus/post_skus_parameters.go
@@ -4,8 +4,11 @@ package skus
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewPostSkusParams() *PostSkusParams {
 
-	return &PostSkusParams{}
+	return &PostSkusParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostSkusParamsWithTimeout creates a new PostSkusParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostSkusParamsWithTimeout(timeout time.Duration) *PostSkusParams {
+
+	return &PostSkusParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostSkusParams contains all the parameters to send to the API endpoint
 for the post skus operation typically these are written to a http.Request
 */
 type PostSkusParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostSkusParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/tags/delete_nodes_identifier_tags_tagname_parameters.go
+++ b/client/tags/delete_nodes_identifier_tags_tagname_parameters.go
@@ -4,8 +4,11 @@ package tags
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierTagsTagnameParams() *DeleteNodesIdentifierTagsTagnameParams {
 	var ()
-	return &DeleteNodesIdentifierTagsTagnameParams{}
+	return &DeleteNodesIdentifierTagsTagnameParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierTagsTagnameParamsWithTimeout creates a new DeleteNodesIdentifierTagsTagnameParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierTagsTagnameParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierTagsTagnameParams {
+	var ()
+	return &DeleteNodesIdentifierTagsTagnameParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierTagsTagnameParams contains all the parameters to send to the API endpoint
@@ -34,23 +50,26 @@ type DeleteNodesIdentifierTagsTagnameParams struct {
 
 	*/
 	Tagname string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier tags tagname params
-func (o *DeleteNodesIdentifierTagsTagnameParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierTagsTagnameParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierTagsTagnameParams) WithIdentifier(identifier string) *DeleteNodesIdentifierTagsTagnameParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithTagname adds the tagname to the delete nodes identifier tags tagname params
-func (o *DeleteNodesIdentifierTagsTagnameParams) WithTagname(Tagname string) *DeleteNodesIdentifierTagsTagnameParams {
-	o.Tagname = Tagname
+func (o *DeleteNodesIdentifierTagsTagnameParams) WithTagname(tagname string) *DeleteNodesIdentifierTagsTagnameParams {
+	o.Tagname = tagname
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierTagsTagnameParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/tags/get_nodes_identifier_tags_parameters.go
+++ b/client/tags/get_nodes_identifier_tags_parameters.go
@@ -4,8 +4,11 @@ package tags
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierTagsParams() *GetNodesIdentifierTagsParams {
 	var ()
-	return &GetNodesIdentifierTagsParams{}
+	return &GetNodesIdentifierTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierTagsParamsWithTimeout creates a new GetNodesIdentifierTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierTagsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierTagsParams {
+	var ()
+	return &GetNodesIdentifierTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierTagsParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetNodesIdentifierTagsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier tags params
-func (o *GetNodesIdentifierTagsParams) WithIdentifier(Identifier string) *GetNodesIdentifierTagsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierTagsParams) WithIdentifier(identifier string) *GetNodesIdentifierTagsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/tags/get_tags_parameters.go
+++ b/client/tags/get_tags_parameters.go
@@ -4,8 +4,11 @@ package tags
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetTagsParams() *GetTagsParams {
 
-	return &GetTagsParams{}
+	return &GetTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetTagsParamsWithTimeout creates a new GetTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetTagsParamsWithTimeout(timeout time.Duration) *GetTagsParams {
+
+	return &GetTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetTagsParams contains all the parameters to send to the API endpoint
 for the get tags operation typically these are written to a http.Request
 */
 type GetTagsParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/tags/patch_nodes_identifier_tags_parameters.go
+++ b/client/tags/patch_nodes_identifier_tags_parameters.go
@@ -4,8 +4,11 @@ package tags
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPatchNodesIdentifierTagsParams() *PatchNodesIdentifierTagsParams {
 	var ()
-	return &PatchNodesIdentifierTagsParams{}
+	return &PatchNodesIdentifierTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPatchNodesIdentifierTagsParamsWithTimeout creates a new PatchNodesIdentifierTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPatchNodesIdentifierTagsParamsWithTimeout(timeout time.Duration) *PatchNodesIdentifierTagsParams {
+	var ()
+	return &PatchNodesIdentifierTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PatchNodesIdentifierTagsParams contains all the parameters to send to the API endpoint
@@ -34,23 +50,26 @@ type PatchNodesIdentifierTagsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the patch nodes identifier tags params
-func (o *PatchNodesIdentifierTagsParams) WithBody(Body interface{}) *PatchNodesIdentifierTagsParams {
-	o.Body = Body
+func (o *PatchNodesIdentifierTagsParams) WithBody(body interface{}) *PatchNodesIdentifierTagsParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the patch nodes identifier tags params
-func (o *PatchNodesIdentifierTagsParams) WithIdentifier(Identifier string) *PatchNodesIdentifierTagsParams {
-	o.Identifier = Identifier
+func (o *PatchNodesIdentifierTagsParams) WithIdentifier(identifier string) *PatchNodesIdentifierTagsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PatchNodesIdentifierTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/tags/post_tags_parameters.go
+++ b/client/tags/post_tags_parameters.go
@@ -4,8 +4,11 @@ package tags
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostTagsParams() *PostTagsParams {
 	var ()
-	return &PostTagsParams{}
+	return &PostTagsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostTagsParamsWithTimeout creates a new PostTagsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostTagsParamsWithTimeout(timeout time.Duration) *PostTagsParams {
+	var ()
+	return &PostTagsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostTagsParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PostTagsParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post tags params
-func (o *PostTagsParams) WithBody(Body interface{}) *PostTagsParams {
-	o.Body = Body
+func (o *PostTagsParams) WithBody(body interface{}) *PostTagsParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostTagsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/task/get_workflows_tasks_parameters.go
+++ b/client/task/get_workflows_tasks_parameters.go
@@ -4,8 +4,11 @@ package task
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsTasksParams() *GetWorkflowsTasksParams {
 
-	return &GetWorkflowsTasksParams{}
+	return &GetWorkflowsTasksParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsTasksParamsWithTimeout creates a new GetWorkflowsTasksParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsTasksParamsWithTimeout(timeout time.Duration) *GetWorkflowsTasksParams {
+
+	return &GetWorkflowsTasksParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsTasksParams contains all the parameters to send to the API endpoint
 for the get workflows tasks operation typically these are written to a http.Request
 */
 type GetWorkflowsTasksParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsTasksParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/task/put_workflows_tasks_parameters.go
+++ b/client/task/put_workflows_tasks_parameters.go
@@ -4,8 +4,11 @@ package task
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutWorkflowsTasksParams() *PutWorkflowsTasksParams {
 	var ()
-	return &PutWorkflowsTasksParams{}
+	return &PutWorkflowsTasksParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutWorkflowsTasksParamsWithTimeout creates a new PutWorkflowsTasksParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutWorkflowsTasksParamsWithTimeout(timeout time.Duration) *PutWorkflowsTasksParams {
+	var ()
+	return &PutWorkflowsTasksParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutWorkflowsTasksParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PutWorkflowsTasksParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the put workflows tasks params
-func (o *PutWorkflowsTasksParams) WithBody(Body interface{}) *PutWorkflowsTasksParams {
-	o.Body = Body
+func (o *PutWorkflowsTasksParams) WithBody(body interface{}) *PutWorkflowsTasksParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutWorkflowsTasksParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/templates/get_pollers_identifier_data_parameters.go
+++ b/client/templates/get_pollers_identifier_data_parameters.go
@@ -4,8 +4,11 @@ package templates
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetPollersIdentifierDataParams() *GetPollersIdentifierDataParams {
 	var ()
-	return &GetPollersIdentifierDataParams{}
+	return &GetPollersIdentifierDataParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetPollersIdentifierDataParamsWithTimeout creates a new GetPollersIdentifierDataParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetPollersIdentifierDataParamsWithTimeout(timeout time.Duration) *GetPollersIdentifierDataParams {
+	var ()
+	return &GetPollersIdentifierDataParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetPollersIdentifierDataParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetPollersIdentifierDataParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get pollers identifier data params
-func (o *GetPollersIdentifierDataParams) WithIdentifier(Identifier string) *GetPollersIdentifierDataParams {
-	o.Identifier = Identifier
+func (o *GetPollersIdentifierDataParams) WithIdentifier(identifier string) *GetPollersIdentifierDataParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetPollersIdentifierDataParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/templates/get_templates_library_identifier_parameters.go
+++ b/client/templates/get_templates_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package templates
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetTemplatesLibraryIdentifierParams() *GetTemplatesLibraryIdentifierParams {
 	var ()
-	return &GetTemplatesLibraryIdentifierParams{}
+	return &GetTemplatesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetTemplatesLibraryIdentifierParamsWithTimeout creates a new GetTemplatesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetTemplatesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *GetTemplatesLibraryIdentifierParams {
+	var ()
+	return &GetTemplatesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetTemplatesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type GetTemplatesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get templates library identifier params
-func (o *GetTemplatesLibraryIdentifierParams) WithIdentifier(Identifier string) *GetTemplatesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *GetTemplatesLibraryIdentifierParams) WithIdentifier(identifier string) *GetTemplatesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetTemplatesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/templates/get_templates_library_parameters.go
+++ b/client/templates/get_templates_library_parameters.go
@@ -4,8 +4,11 @@ package templates
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetTemplatesLibraryParams() *GetTemplatesLibraryParams {
 
-	return &GetTemplatesLibraryParams{}
+	return &GetTemplatesLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetTemplatesLibraryParamsWithTimeout creates a new GetTemplatesLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetTemplatesLibraryParamsWithTimeout(timeout time.Duration) *GetTemplatesLibraryParams {
+
+	return &GetTemplatesLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetTemplatesLibraryParams contains all the parameters to send to the API endpoint
 for the get templates library operation typically these are written to a http.Request
 */
 type GetTemplatesLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetTemplatesLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/templates/put_templates_library_identifier_parameters.go
+++ b/client/templates/put_templates_library_identifier_parameters.go
@@ -4,8 +4,11 @@ package templates
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutTemplatesLibraryIdentifierParams() *PutTemplatesLibraryIdentifierParams {
 	var ()
-	return &PutTemplatesLibraryIdentifierParams{}
+	return &PutTemplatesLibraryIdentifierParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutTemplatesLibraryIdentifierParamsWithTimeout creates a new PutTemplatesLibraryIdentifierParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutTemplatesLibraryIdentifierParamsWithTimeout(timeout time.Duration) *PutTemplatesLibraryIdentifierParams {
+	var ()
+	return &PutTemplatesLibraryIdentifierParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutTemplatesLibraryIdentifierParams contains all the parameters to send to the API endpoint
@@ -28,17 +44,20 @@ type PutTemplatesLibraryIdentifierParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the put templates library identifier params
-func (o *PutTemplatesLibraryIdentifierParams) WithIdentifier(Identifier string) *PutTemplatesLibraryIdentifierParams {
-	o.Identifier = Identifier
+func (o *PutTemplatesLibraryIdentifierParams) WithIdentifier(identifier string) *PutTemplatesLibraryIdentifierParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutTemplatesLibraryIdentifierParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/versions/get_versions_parameters.go
+++ b/client/versions/get_versions_parameters.go
@@ -4,8 +4,11 @@ package versions
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetVersionsParams() *GetVersionsParams {
 
-	return &GetVersionsParams{}
+	return &GetVersionsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetVersionsParamsWithTimeout creates a new GetVersionsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetVersionsParamsWithTimeout(timeout time.Duration) *GetVersionsParams {
+
+	return &GetVersionsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetVersionsParams contains all the parameters to send to the API endpoint
 for the get versions operation typically these are written to a http.Request
 */
 type GetVersionsParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetVersionsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/whitelist/delete_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/whitelist/delete_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package whitelist
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesMacaddressDhcpWhitelistParams() *DeleteNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &DeleteNodesMacaddressDhcpWhitelistParams{}
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new DeleteNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *DeleteNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &DeleteNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithMacaddress adds the macaddress to the delete nodes macaddress dhcp whitelist params
-func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *DeleteNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *DeleteNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param macaddress

--- a/client/whitelist/post_nodes_macaddress_dhcp_whitelist_parameters.go
+++ b/client/whitelist/post_nodes_macaddress_dhcp_whitelist_parameters.go
@@ -4,8 +4,11 @@ package whitelist
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesMacaddressDhcpWhitelistParams() *PostNodesMacaddressDhcpWhitelistParams {
 	var ()
-	return &PostNodesMacaddressDhcpWhitelistParams{}
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout creates a new PostNodesMacaddressDhcpWhitelistParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesMacaddressDhcpWhitelistParamsWithTimeout(timeout time.Duration) *PostNodesMacaddressDhcpWhitelistParams {
+	var ()
+	return &PostNodesMacaddressDhcpWhitelistParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesMacaddressDhcpWhitelistParams contains all the parameters to send to the API endpoint
@@ -31,23 +47,26 @@ type PostNodesMacaddressDhcpWhitelistParams struct {
 
 	*/
 	Macaddress string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(Body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Body = Body
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithBody(body interface{}) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Body = body
 	return o
 }
 
 // WithMacaddress adds the macaddress to the post nodes macaddress dhcp whitelist params
-func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(Macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
-	o.Macaddress = Macaddress
+func (o *PostNodesMacaddressDhcpWhitelistParams) WithMacaddress(macaddress string) *PostNodesMacaddressDhcpWhitelistParams {
+	o.Macaddress = macaddress
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesMacaddressDhcpWhitelistParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/workflow/delete_nodes_identifier_workflows_active_parameters.go
+++ b/client/workflow/delete_nodes_identifier_workflows_active_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteNodesIdentifierWorkflowsActiveParams() *DeleteNodesIdentifierWorkflowsActiveParams {
 	var ()
-	return &DeleteNodesIdentifierWorkflowsActiveParams{}
+	return &DeleteNodesIdentifierWorkflowsActiveParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteNodesIdentifierWorkflowsActiveParamsWithTimeout creates a new DeleteNodesIdentifierWorkflowsActiveParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteNodesIdentifierWorkflowsActiveParamsWithTimeout(timeout time.Duration) *DeleteNodesIdentifierWorkflowsActiveParams {
+	var ()
+	return &DeleteNodesIdentifierWorkflowsActiveParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteNodesIdentifierWorkflowsActiveParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type DeleteNodesIdentifierWorkflowsActiveParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the delete nodes identifier workflows active params
-func (o *DeleteNodesIdentifierWorkflowsActiveParams) WithIdentifier(Identifier string) *DeleteNodesIdentifierWorkflowsActiveParams {
-	o.Identifier = Identifier
+func (o *DeleteNodesIdentifierWorkflowsActiveParams) WithIdentifier(identifier string) *DeleteNodesIdentifierWorkflowsActiveParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteNodesIdentifierWorkflowsActiveParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/workflow/get_nodes_identifier_workflows_active_parameters.go
+++ b/client/workflow/get_nodes_identifier_workflows_active_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierWorkflowsActiveParams() *GetNodesIdentifierWorkflowsActiveParams {
 	var ()
-	return &GetNodesIdentifierWorkflowsActiveParams{}
+	return &GetNodesIdentifierWorkflowsActiveParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierWorkflowsActiveParamsWithTimeout creates a new GetNodesIdentifierWorkflowsActiveParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierWorkflowsActiveParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierWorkflowsActiveParams {
+	var ()
+	return &GetNodesIdentifierWorkflowsActiveParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierWorkflowsActiveParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierWorkflowsActiveParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier workflows active params
-func (o *GetNodesIdentifierWorkflowsActiveParams) WithIdentifier(Identifier string) *GetNodesIdentifierWorkflowsActiveParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierWorkflowsActiveParams) WithIdentifier(identifier string) *GetNodesIdentifierWorkflowsActiveParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierWorkflowsActiveParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/workflow/get_nodes_identifier_workflows_parameters.go
+++ b/client/workflow/get_nodes_identifier_workflows_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetNodesIdentifierWorkflowsParams() *GetNodesIdentifierWorkflowsParams {
 	var ()
-	return &GetNodesIdentifierWorkflowsParams{}
+	return &GetNodesIdentifierWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetNodesIdentifierWorkflowsParamsWithTimeout creates a new GetNodesIdentifierWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetNodesIdentifierWorkflowsParamsWithTimeout(timeout time.Duration) *GetNodesIdentifierWorkflowsParams {
+	var ()
+	return &GetNodesIdentifierWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetNodesIdentifierWorkflowsParams contains all the parameters to send to the API endpoint
@@ -29,17 +45,20 @@ type GetNodesIdentifierWorkflowsParams struct {
 
 	*/
 	Identifier string
+
+	timeout time.Duration
 }
 
 // WithIdentifier adds the identifier to the get nodes identifier workflows params
-func (o *GetNodesIdentifierWorkflowsParams) WithIdentifier(Identifier string) *GetNodesIdentifierWorkflowsParams {
-	o.Identifier = Identifier
+func (o *GetNodesIdentifierWorkflowsParams) WithIdentifier(identifier string) *GetNodesIdentifierWorkflowsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetNodesIdentifierWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param identifier

--- a/client/workflow/get_workflows_instance_id_parameters.go
+++ b/client/workflow/get_workflows_instance_id_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsInstanceIDParams() *GetWorkflowsInstanceIDParams {
 	var ()
-	return &GetWorkflowsInstanceIDParams{}
+	return &GetWorkflowsInstanceIDParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsInstanceIDParamsWithTimeout creates a new GetWorkflowsInstanceIDParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsInstanceIDParamsWithTimeout(timeout time.Duration) *GetWorkflowsInstanceIDParams {
+	var ()
+	return &GetWorkflowsInstanceIDParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsInstanceIDParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type GetWorkflowsInstanceIDParams struct {
 
 	/*InstanceID*/
 	InstanceID string
+
+	timeout time.Duration
 }
 
-// WithInstanceID adds the instanceId to the get workflows instance ID params
-func (o *GetWorkflowsInstanceIDParams) WithInstanceID(InstanceID string) *GetWorkflowsInstanceIDParams {
-	o.InstanceID = InstanceID
+// WithInstanceID adds the instanceID to the get workflows instance ID params
+func (o *GetWorkflowsInstanceIDParams) WithInstanceID(instanceID string) *GetWorkflowsInstanceIDParams {
+	o.InstanceID = instanceID
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsInstanceIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param instanceId

--- a/client/workflow/get_workflows_library_injectable_name_parameters.go
+++ b/client/workflow/get_workflows_library_injectable_name_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsLibraryInjectableNameParams() *GetWorkflowsLibraryInjectableNameParams {
 	var ()
-	return &GetWorkflowsLibraryInjectableNameParams{}
+	return &GetWorkflowsLibraryInjectableNameParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsLibraryInjectableNameParamsWithTimeout creates a new GetWorkflowsLibraryInjectableNameParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsLibraryInjectableNameParamsWithTimeout(timeout time.Duration) *GetWorkflowsLibraryInjectableNameParams {
+	var ()
+	return &GetWorkflowsLibraryInjectableNameParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsLibraryInjectableNameParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type GetWorkflowsLibraryInjectableNameParams struct {
 
 	/*InjectableName*/
 	InjectableName string
+
+	timeout time.Duration
 }
 
 // WithInjectableName adds the injectableName to the get workflows library injectable name params
-func (o *GetWorkflowsLibraryInjectableNameParams) WithInjectableName(InjectableName string) *GetWorkflowsLibraryInjectableNameParams {
-	o.InjectableName = InjectableName
+func (o *GetWorkflowsLibraryInjectableNameParams) WithInjectableName(injectableName string) *GetWorkflowsLibraryInjectableNameParams {
+	o.InjectableName = injectableName
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsLibraryInjectableNameParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param injectableName

--- a/client/workflow/get_workflows_library_parameters.go
+++ b/client/workflow/get_workflows_library_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsLibraryParams() *GetWorkflowsLibraryParams {
 
-	return &GetWorkflowsLibraryParams{}
+	return &GetWorkflowsLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsLibraryParamsWithTimeout creates a new GetWorkflowsLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsLibraryParamsWithTimeout(timeout time.Duration) *GetWorkflowsLibraryParams {
+
+	return &GetWorkflowsLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsLibraryParams contains all the parameters to send to the API endpoint
 for the get workflows library operation typically these are written to a http.Request
 */
 type GetWorkflowsLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/workflow/get_workflows_parameters.go
+++ b/client/workflow/get_workflows_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsParams() *GetWorkflowsParams {
 
-	return &GetWorkflowsParams{}
+	return &GetWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsParamsWithTimeout creates a new GetWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsParamsWithTimeout(timeout time.Duration) *GetWorkflowsParams {
+
+	return &GetWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsParams contains all the parameters to send to the API endpoint
 for the get workflows operation typically these are written to a http.Request
 */
 type GetWorkflowsParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/workflow/get_workflows_tasks_library_parameters.go
+++ b/client/workflow/get_workflows_tasks_library_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsTasksLibraryParams() *GetWorkflowsTasksLibraryParams {
 
-	return &GetWorkflowsTasksLibraryParams{}
+	return &GetWorkflowsTasksLibraryParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsTasksLibraryParamsWithTimeout creates a new GetWorkflowsTasksLibraryParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsTasksLibraryParamsWithTimeout(timeout time.Duration) *GetWorkflowsTasksLibraryParams {
+
+	return &GetWorkflowsTasksLibraryParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsTasksLibraryParams contains all the parameters to send to the API endpoint
 for the get workflows tasks library operation typically these are written to a http.Request
 */
 type GetWorkflowsTasksLibraryParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsTasksLibraryParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/workflow/get_workflows_tasks_parameters.go
+++ b/client/workflow/get_workflows_tasks_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetWorkflowsTasksParams() *GetWorkflowsTasksParams {
 
-	return &GetWorkflowsTasksParams{}
+	return &GetWorkflowsTasksParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetWorkflowsTasksParamsWithTimeout creates a new GetWorkflowsTasksParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetWorkflowsTasksParamsWithTimeout(timeout time.Duration) *GetWorkflowsTasksParams {
+
+	return &GetWorkflowsTasksParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetWorkflowsTasksParams contains all the parameters to send to the API endpoint
 for the get workflows tasks operation typically these are written to a http.Request
 */
 type GetWorkflowsTasksParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetWorkflowsTasksParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/client/workflow/post_nodes_identifier_workflows_parameters.go
+++ b/client/workflow/post_nodes_identifier_workflows_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostNodesIdentifierWorkflowsParams() *PostNodesIdentifierWorkflowsParams {
 	var ()
-	return &PostNodesIdentifierWorkflowsParams{}
+	return &PostNodesIdentifierWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostNodesIdentifierWorkflowsParamsWithTimeout creates a new PostNodesIdentifierWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostNodesIdentifierWorkflowsParamsWithTimeout(timeout time.Duration) *PostNodesIdentifierWorkflowsParams {
+	var ()
+	return &PostNodesIdentifierWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostNodesIdentifierWorkflowsParams contains all the parameters to send to the API endpoint
@@ -36,29 +52,32 @@ type PostNodesIdentifierWorkflowsParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithBody(Body interface{}) *PostNodesIdentifierWorkflowsParams {
-	o.Body = Body
+func (o *PostNodesIdentifierWorkflowsParams) WithBody(body interface{}) *PostNodesIdentifierWorkflowsParams {
+	o.Body = body
 	return o
 }
 
 // WithIdentifier adds the identifier to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithIdentifier(Identifier string) *PostNodesIdentifierWorkflowsParams {
-	o.Identifier = Identifier
+func (o *PostNodesIdentifierWorkflowsParams) WithIdentifier(identifier string) *PostNodesIdentifierWorkflowsParams {
+	o.Identifier = identifier
 	return o
 }
 
 // WithName adds the name to the post nodes identifier workflows params
-func (o *PostNodesIdentifierWorkflowsParams) WithName(Name string) *PostNodesIdentifierWorkflowsParams {
-	o.Name = Name
+func (o *PostNodesIdentifierWorkflowsParams) WithName(name string) *PostNodesIdentifierWorkflowsParams {
+	o.Name = name
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostNodesIdentifierWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/workflow/post_workflows_parameters.go
+++ b/client/workflow/post_workflows_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPostWorkflowsParams() *PostWorkflowsParams {
 	var ()
-	return &PostWorkflowsParams{}
+	return &PostWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPostWorkflowsParamsWithTimeout creates a new PostWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPostWorkflowsParamsWithTimeout(timeout time.Duration) *PostWorkflowsParams {
+	var ()
+	return &PostWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PostWorkflowsParams contains all the parameters to send to the API endpoint
@@ -30,23 +46,26 @@ type PostWorkflowsParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the post workflows params
-func (o *PostWorkflowsParams) WithBody(Body interface{}) *PostWorkflowsParams {
-	o.Body = Body
+func (o *PostWorkflowsParams) WithBody(body interface{}) *PostWorkflowsParams {
+	o.Body = body
 	return o
 }
 
 // WithName adds the name to the post workflows params
-func (o *PostWorkflowsParams) WithName(Name string) *PostWorkflowsParams {
-	o.Name = Name
+func (o *PostWorkflowsParams) WithName(name string) *PostWorkflowsParams {
+	o.Name = name
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PostWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/workflow/put_workflows_parameters.go
+++ b/client/workflow/put_workflows_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutWorkflowsParams() *PutWorkflowsParams {
 	var ()
-	return &PutWorkflowsParams{}
+	return &PutWorkflowsParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutWorkflowsParamsWithTimeout creates a new PutWorkflowsParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutWorkflowsParamsWithTimeout(timeout time.Duration) *PutWorkflowsParams {
+	var ()
+	return &PutWorkflowsParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutWorkflowsParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PutWorkflowsParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the put workflows params
-func (o *PutWorkflowsParams) WithBody(Body interface{}) *PutWorkflowsParams {
-	o.Body = Body
+func (o *PutWorkflowsParams) WithBody(body interface{}) *PutWorkflowsParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/client/workflow/put_workflows_tasks_parameters.go
+++ b/client/workflow/put_workflows_tasks_parameters.go
@@ -4,8 +4,11 @@ package workflow
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewPutWorkflowsTasksParams() *PutWorkflowsTasksParams {
 	var ()
-	return &PutWorkflowsTasksParams{}
+	return &PutWorkflowsTasksParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewPutWorkflowsTasksParamsWithTimeout creates a new PutWorkflowsTasksParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewPutWorkflowsTasksParamsWithTimeout(timeout time.Duration) *PutWorkflowsTasksParams {
+	var ()
+	return &PutWorkflowsTasksParams{
+
+		timeout: timeout,
+	}
 }
 
 /*PutWorkflowsTasksParams contains all the parameters to send to the API endpoint
@@ -24,17 +40,20 @@ type PutWorkflowsTasksParams struct {
 
 	/*Body*/
 	Body interface{}
+
+	timeout time.Duration
 }
 
 // WithBody adds the body to the put workflows tasks params
-func (o *PutWorkflowsTasksParams) WithBody(Body interface{}) *PutWorkflowsTasksParams {
-	o.Body = Body
+func (o *PutWorkflowsTasksParams) WithBody(body interface{}) *PutWorkflowsTasksParams {
+	o.Body = body
 	return o
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *PutWorkflowsTasksParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if err := r.SetBodyParam(o.Body); err != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,53 +1,106 @@
-hash: 70287950b3bbe43c249f1c4e01ea98063a462e8f4c9dd751b3bab3018e4b03c2
-updated: 2016-08-15T13:28:23.592271813-07:00
+hash: 344fd89f698e61f6248b794b637fc0c577e374bdb80622d826b543716c680bc1
+updated: 2016-09-07T15:07:11.615865225-07:00
 imports:
 - name: github.com/asaskevich/govalidator
-  version: df81827fdd59d8b4fb93d8910b286ab7a3919520
+  version: 593d64559f7600f29581a3ee42177f5dbded27a9
   repo: https://github.com/asaskevich/govalidator
+- name: github.com/codedellemc/gorackhd
+  version: 92f5e99ea8af0d4afbd96ba3573bd0405be28975
+  subpackages:
+  - client
+  - client/catalog
+  - client/catalogs
+  - client/config
+  - client/delete
+  - client/dhcp
+  - client/files
+  - client/get
+  - client/identify
+  - client/lookups
+  - client/nodes
+  - client/obm
+  - client/obms
+  - client/patch
+  - client/pollers
+  - client/post
+  - client/profiles
+  - client/put
+  - client/skus
+  - client/tags
+  - client/task
+  - client/templates
+  - client/versions
+  - client/whitelist
+  - client/workflow
+  - models
 - name: github.com/go-openapi/analysis
-  version: 5a8fe2138f95138797c306c07e65e759c55f898f
+  version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
   repo: https://github.com/go-openapi/analysis
 - name: github.com/go-openapi/errors
-  version: 8a4ac38004d8cdb96dac7bece88034dd3d94493f
-  repo: https://github.com/go-openapi/errors
+  version: 4178436c9f2430cdd945c50301cfb61563b56573
 - name: github.com/go-openapi/jsonpointer
-  version: f5133566e18f23f2085d953998fd72959b698623
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
   repo: https://github.com/go-openapi/jsonpointer
 - name: github.com/go-openapi/jsonreference
-  version: 44d0c05f81b60f99eeb8c188b8983ec82e5d872f
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
   repo: https://github.com/go-openapi/jsonreference
 - name: github.com/go-openapi/loads
-  version: 3a4490f96e6ea1ba7d66602e70ffca0fc26aa6ca
+  version: 18441dfa706d924a39a030ee2c3b1d8d81917b38
   repo: https://github.com/go-openapi/loads
 - name: github.com/go-openapi/runtime
-  version: b12d766cb7ccfdac98c946f9f0ab4afa8c6aeadc
+  version: 18efe8c11921c0ddabc8e91554971d6db1f91c7c
   subpackages:
   - client
 - name: github.com/go-openapi/spec
-  version: 2029f5179022b7e840b71a663b1fda7fb24e49a0
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
   repo: https://github.com/go-openapi/spec
 - name: github.com/go-openapi/strfmt
-  version: 66a99d45c3043d45d346b1c8db5dc2f76a004869
-  repo: https://github.com/go-openapi/strfmt
+  version: d65c7fdb29eca313476e529628176fe17e58c488
 - name: github.com/go-openapi/swag
-  version: f8ab07bb33bb43a743eb65daf0588ab522e5160f
-  repo: https://github.com/go-openapi/swag
+  version: 0e04f5e499b19bf51031c01a00f098f25067d8dc
 - name: github.com/go-openapi/validate
   version: 14872542e3bd537d6d6b9976e066ff658d41975f
 - name: github.com/go-swagger/go-swagger
-  version: fade7c68fe6ea117733051b041c590569c428d67
+  version: 4c101d534a9bc418b0c47c4e017153f317304ca4
   vcs: git
-- name: github.com/opennota/urlesc
-  version: 5fa9ff0392746aeae1c4b37fcc42c65afa7a9587
-  repo: https://github.com/opennota/urlesc
+- name: github.com/mailru/easyjson
+  version: 34560e358dc05e2c28f6fda2f5c9e7494a4b9b19
+  repo: https://github.com/mailru/easyjson
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
 - name: github.com/PuerkitoBio/purell
-  version: d69616f51cdfcd7514d6a380847a152dfc2a749d
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
   repo: https://github.com/PuerkitoBio/purell
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  repo: https://github.com/PuerkitoBio/urlesc
 - name: golang.org/x/net
-  version: 0c607074acd38c5f23d1344dfe74c977464d1257
+  version: 9bc2a3340c92c17a20edcd0080e93851ed58f5d5
   repo: https://go.googlesource.com/net
   subpackages:
   - context
-  - netutil
   - context/ctxhttp
-devImports: []
+  - idna
+  - netutil
+- name: golang.org/x/text
+  version: 09c7ea1fcb3345da09be5a32c9c52303acd1dc2c
+  repo: https://go.googlesource.com/text
+  subpackages:
+  - cases
+  - internal/gen
+  - internal/tag
+  - internal/triegen
+  - internal/ucd
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/cldr
+  - unicode/norm
+  - unicode/rangetable
+  - width
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,5 @@
 package: github.com/codedellemc/gorackhd
 import:
   - package: github.com/go-swagger/go-swagger
-    version: 0.5.9
+    version: 0.6.0
     vcs:     git

--- a/gorackhd_test.go
+++ b/gorackhd_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	httptransport "github.com/go-openapi/runtime/client"
+	rc "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
 	apiclient "github.com/codedellemc/gorackhd/client"
@@ -18,7 +18,7 @@ import (
 func TestNodeGetOperation(t *testing.T) {
 
 	// create the transport
-	transport := httptransport.New("localhost:9090", "/api/1.1", []string{"http"})
+	transport := rc.New("localhost:9090", "/api/1.1", []string{"http"})
 
 	// configure the host. include port with environment variable. For instance the vagrant image would be localhost:9090
 	if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -39,7 +39,7 @@ func TestNodeGetOperation(t *testing.T) {
 func TestNodeLookupOperation(t *testing.T) {
 
 	// create the transport
-	transport := httptransport.New("localhost:9090", "/api/1.1", []string{"http"})
+	transport := rc.New("localhost:9090", "/api/1.1", []string{"http"})
 
 	// configure the host. include port with environment variable. For instance the vagrant image would be localhost:9090
 	if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -50,8 +50,10 @@ func TestNodeLookupOperation(t *testing.T) {
 	client := apiclient.New(transport, strfmt.Default)
 
 	nodeId := "56dde3441722c192796e3a38"
+	params := lookups.NewGetLookupsParams()
+	params = params.WithQ(&nodeId)
 	//use any function to do REST operations
-	resp, err := client.Lookups.GetLookups(&lookups.GetLookupsParams{Q: &nodeId}, nil)
+	resp, err := client.Lookups.GetLookups(params, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -61,7 +63,7 @@ func TestNodeLookupOperation(t *testing.T) {
 func TestNodePostOperation(t *testing.T) {
 
 	// create the transport
-	transport := httptransport.New("localhost:9090", "/api/1.1", []string{"http"})
+	transport := rc.New("localhost:9090", "/api/1.1", []string{"http"})
 
 	// configure the host
 	if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -91,7 +93,9 @@ func TestNodePostOperation(t *testing.T) {
 	}
 	fmt.Println(string(b))
 
-	resp, err := client.Nodes.PostNodes(&nodes.PostNodesParams{Identifiers: c}, nil)
+	params := nodes.NewPostNodesParams()
+	params = params.WithIdentifiers(c)
+	resp, err := client.Nodes.PostNodes(params, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -101,7 +105,7 @@ func TestNodePostOperation(t *testing.T) {
 func TestNodeDeleteOperation(t *testing.T) {
 
 	// create the transport
-	transport := httptransport.New("localhost:9090", "/api/1.1", []string{"http"})
+	transport := rc.New("localhost:9090", "/api/1.1", []string{"http"})
 
 	// configure the host. include port with environment variable. For instance the vagrant image would be localhost:9090
 	if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -111,8 +115,9 @@ func TestNodeDeleteOperation(t *testing.T) {
 	// create the API client, with the transport
 	client := apiclient.New(transport, strfmt.Default)
 
-	//use any function to do REST operations
-	resp, err := client.Nodes.DeleteNodesIdentifier(&nodes.DeleteNodesIdentifierParams{Identifier: "1234abcd1234abcd1234abcd"}, nil)
+	params := nodes.NewDeleteNodesIdentifierParams()
+	params = params.WithIdentifier("1234abcd1234abcd1234abcd")
+	resp, err := client.Nodes.DeleteNodesIdentifier(params, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Updates to generate code using Swagger 0.6.0. We can now use the same version of go-swagger for `gorackhd` and `gorackhd-redfish`, which eliminates a lot of headache.j

Biggest change is how to initialize request params. You have to use the generated helper methods, otherwise you end with a request timeout of 0, which will immediately fail.
